### PR TITLE
Classe Boleto passou a conter informacoes da Carteira

### DIFF
--- a/Boleto2.Net.Testes/BancoBradescoCarteira09.cs
+++ b/Boleto2.Net.Testes/BancoBradescoCarteira09.cs
@@ -14,8 +14,8 @@ namespace Boleto2Net.Testes
                 DigitoAgencia = "X",
                 Conta = "123456",
                 DigitoConta = "X",
-                Carteira = "09",
-                TipoCarteira = TipoCarteira.CarteiraCobrancaSimples,
+                CarteiraPadrao = "09",
+                TipoCarteiraPadrao = TipoCarteira.CarteiraCobrancaSimples,
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
@@ -45,14 +45,13 @@ namespace Boleto2Net.Testes
         public void Bradesco_09_BoletoOK(decimal valorTitulo, string nossoNumero, string numeroDocumento, string digitoVerificador, string nossoNumeroFormatado, string codigoDeBarras, string linhaDigitavel, params int[] anoMesDia)
         {
             //Ambiente
-            var boleto = new Boleto
+            var boleto = new Boleto(_banco)
             {
                 DataVencimento = new DateTime(anoMesDia[0], anoMesDia[1], anoMesDia[2]),
                 ValorTitulo = valorTitulo,
                 NossoNumero = nossoNumero,
                 NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = _banco,
                 Sacado = Utils.GerarSacado()
             };
 

--- a/Boleto2.Net.Testes/BancoBrasilCarteira11_019Tests.cs
+++ b/Boleto2.Net.Testes/BancoBrasilCarteira11_019Tests.cs
@@ -14,9 +14,9 @@ namespace Boleto2Net.Testes
                 DigitoAgencia = "X",
                 Conta = "123456",
                 DigitoConta = "X",
-                Carteira = "11",
-                VariacaoCarteira = "019",
-                TipoCarteira = TipoCarteira.CarteiraCobrancaSimples,
+                CarteiraPadrao = "11",
+                VariacaoCarteiraPadrao = "019",
+                TipoCarteiraPadrao = TipoCarteira.CarteiraCobrancaSimples,
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };

--- a/Boleto2.Net.Testes/BancoBrasilCarteira17_019Tests.cs
+++ b/Boleto2.Net.Testes/BancoBrasilCarteira17_019Tests.cs
@@ -14,9 +14,9 @@ namespace Boleto2Net.Testes
                 DigitoAgencia = "X",
                 Conta = "123456",
                 DigitoConta = "X",
-                Carteira = "17",
-                VariacaoCarteira = "019",
-                TipoCarteira = TipoCarteira.CarteiraCobrancaSimples,
+                CarteiraPadrao = "17",
+                VariacaoCarteiraPadrao = "019",
+                TipoCarteiraPadrao = TipoCarteira.CarteiraCobrancaSimples,
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
@@ -53,14 +53,13 @@ namespace Boleto2Net.Testes
         public void Brasil_17_019_BoletoOK(decimal valorTitulo, string nossoNumero, string numeroDocumento, string digitoVerificador, string nossoNumeroFormatado, string codigoDeBarras, string linhaDigitavel, params int[] anoMesDia)
         {
             //Ambiente
-            var boleto = new Boleto
+            var boleto = new Boleto(_banco)
             {
                 DataVencimento = new DateTime(anoMesDia[0], anoMesDia[1], anoMesDia[2]),
                 ValorTitulo = valorTitulo,
                 NossoNumero = nossoNumero,
                 NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = _banco,
                 Sacado = Utils.GerarSacado()
             };
 

--- a/Boleto2.Net.Testes/BancoCaixaCarteiraSig14Tests.cs
+++ b/Boleto2.Net.Testes/BancoCaixaCarteiraSig14Tests.cs
@@ -15,8 +15,8 @@ namespace Boleto2Net.Testes
                 DigitoAgencia = "X",
                 Conta = "123456",
                 DigitoConta = "X",
-                Carteira = "SIG14",
-                TipoCarteira = TipoCarteira.CarteiraCobrancaSimples,
+                CarteiraPadrao = "SIG14",
+                TipoCarteiraPadrao = TipoCarteira.CarteiraCobrancaSimples,
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
@@ -46,14 +46,13 @@ namespace Boleto2Net.Testes
         public void Caixa_SIG14_BoletoOK(decimal valorTitulo, string nossoNumero, string numeroDocumento, string digitoVerificador, string nossoNumeroFormatado, string codigoDeBarras, string linhaDigitavel, params int[] anoMesDia)
         {
             //Ambiente
-            var boleto = new Boleto
+            var boleto = new Boleto(_banco)
             {
                 DataVencimento = new DateTime(anoMesDia[0], anoMesDia[1], anoMesDia[2]),
                 ValorTitulo = valorTitulo,
                 NossoNumero = nossoNumero,
                 NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = _banco,
                 Sacado = Utils.GerarSacado()
             };
 

--- a/Boleto2.Net.Testes/BancoItauCarteira109Tests.cs
+++ b/Boleto2.Net.Testes/BancoItauCarteira109Tests.cs
@@ -14,8 +14,8 @@ namespace Boleto2Net.Testes
                 DigitoAgencia = "",
                 Conta = "56789",
                 DigitoConta = "0",
-                Carteira = "109",
-                TipoCarteira = TipoCarteira.CarteiraCobrancaSimples,
+                CarteiraPadrao = "109",
+                TipoCarteiraPadrao = TipoCarteira.CarteiraCobrancaSimples,
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
@@ -46,14 +46,13 @@ namespace Boleto2Net.Testes
         public void Itau_109_BoletoOK(decimal valorTitulo, string nossoNumero, string numeroDocumento, string digitoVerificador, string nossoNumeroFormatado, string codigoDeBarras, string linhaDigitavel, params int[] anoMesDia)
         {
             //Ambiente
-            var boleto = new Boleto
+            var boleto = new Boleto(_banco)
             {
                 DataVencimento = new DateTime(anoMesDia[0], anoMesDia[1], anoMesDia[2]),
                 ValorTitulo = valorTitulo,
                 NossoNumero = nossoNumero,
                 NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = _banco,
                 Sacado = Utils.GerarSacado()
             };
 

--- a/Boleto2.Net.Testes/BancoSantanderCarteira101Tests.cs
+++ b/Boleto2.Net.Testes/BancoSantanderCarteira101Tests.cs
@@ -14,8 +14,8 @@ namespace Boleto2Net.Testes
                 DigitoAgencia = "5",
                 Conta = "12345678",
                 DigitoConta = "9",
-                Carteira = "101",
-                TipoCarteira = TipoCarteira.CarteiraCobrancaSimples,
+                CarteiraPadrao = "101",
+                TipoCarteiraPadrao = TipoCarteira.CarteiraCobrancaSimples,
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
@@ -44,14 +44,13 @@ namespace Boleto2Net.Testes
         public void Santander_101_BoletoOK(decimal valorTitulo, string nossoNumero, string numeroDocumento, string digitoVerificador, string nossoNumeroFormatado, string codigoDeBarras, string linhaDigitavel, params int[] anoMesDia)
         {
             //Ambiente
-            var boleto = new Boleto
+            var boleto = new Boleto(_banco)
             {
                 DataVencimento = new DateTime(anoMesDia[0], anoMesDia[1], anoMesDia[2]),
                 ValorTitulo = valorTitulo,
                 NossoNumero = nossoNumero,
                 NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = _banco,
                 Sacado = Utils.GerarSacado()
             };
 

--- a/Boleto2.Net.Testes/BancoSicoobCarteira1_01Tests.cs
+++ b/Boleto2.Net.Testes/BancoSicoobCarteira1_01Tests.cs
@@ -14,9 +14,9 @@ namespace Boleto2Net.Testes
                 DigitoAgencia = "3",
                 Conta = "6498",
                 DigitoConta = "0",
-                Carteira = "1",
-                VariacaoCarteira = "01",
-                TipoCarteira = TipoCarteira.CarteiraCobrancaSimples,
+                CarteiraPadrao = "1",
+                VariacaoCarteiraPadrao = "01",
+                TipoCarteiraPadrao = TipoCarteira.CarteiraCobrancaSimples,
                 TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
@@ -52,14 +52,13 @@ namespace Boleto2Net.Testes
         public void Sicoob_1_01_BoletoOK(decimal valorTitulo, string nossoNumero, string numeroDocumento, string digitoVerificador, string nossoNumeroFormatado, string codigoDeBarras, string linhaDigitavel, params int[] anoMesDia)
         {
             //Ambiente
-            var boleto = new Boleto
+            var boleto = new Boleto(_banco)
             {
                 DataVencimento = new DateTime(anoMesDia[0], anoMesDia[1], anoMesDia[2]),
                 ValorTitulo = valorTitulo,
                 NossoNumero = nossoNumero,
                 NumeroDocumento = numeroDocumento,
                 EspecieDocumento = TipoEspecieDocumento.DM,
-                Banco = _banco,
                 Sacado = Utils.GerarSacado()
             };
 

--- a/Boleto2.Net.Testes/Utils.cs
+++ b/Boleto2.Net.Testes/Utils.cs
@@ -85,9 +85,8 @@ namespace Boleto2Net.Testes
             if (aceite == "?")
                 aceite = _contador % 2 == 0 ? "N" : "A";
 
-            var boleto = new Boleto
+            var boleto = new Boleto(banco)
             {
-                Banco = banco,
                 Sacado = GerarSacado(),
                 DataEmissao = DateTime.Now.AddDays(-3),
                 DataProcessamento = DateTime.Now,

--- a/Boleto2.Net/Arquivo/ArquivoRemessa.cs
+++ b/Boleto2.Net/Arquivo/ArquivoRemessa.cs
@@ -62,7 +62,7 @@ namespace Boleto2Net
                     
                     // Ajusta Totalizadores
                     valorBoletoGeral += boleto.ValorTitulo;
-                    switch (boleto.Banco.Cedente.ContaBancaria.TipoCarteira)
+                    switch (boleto.TipoCarteira)
                     {
                         case TipoCarteira.CarteiraCobrancaSimples:
                             numeroRegistroCobrancaSimples++;

--- a/Boleto2.Net/Arquivo/ArquivoRetorno.cs
+++ b/Boleto2.Net/Arquivo/ArquivoRetorno.cs
@@ -58,10 +58,7 @@ namespace Boleto2Net
             if (tipoRegistro == "3" & tipoSegmento == "T")
             {
                 // Segmento T - Indica um novo boleto
-                var boleto = new Boleto
-                {
-                    Banco = this.Banco
-                };
+                var boleto = new Boleto(this.Banco);
                 Banco.LerDetalheRetornoCNAB240SegmentoT(ref boleto, registro);
                 Boletos.Add(boleto);
             }
@@ -110,10 +107,7 @@ namespace Boleto2Net
             Boleto boleto;
             if (novoBoleto)
             {
-                boleto = new Boleto
-                {
-                    Banco = this.Banco
-                };
+                boleto = new Boleto(this.Banco);
             }
             else
             {

--- a/Boleto2.Net/Banco/Banco.cs
+++ b/Boleto2.Net/Banco/Banco.cs
@@ -39,6 +39,12 @@ namespace Boleto2Net
 
         public List<string> IdsRetornoCnab400RegistroDetalhe => _banco.IdsRetornoCnab400RegistroDetalhe;
 
+        public Boleto NovoBoleto()
+        {
+            var boleto = new Boleto(_banco);
+            return boleto;
+        }
+
         /// <summary>
         ///     Formata Cedente
         /// </summary>

--- a/Boleto2.Net/Banco/BancoBradesco.cs
+++ b/Boleto2.Net/Banco/BancoBradesco.cs
@@ -23,8 +23,8 @@ namespace Boleto2Net
         {
             var contaBancaria = Cedente.ContaBancaria;
 
-            if (!CarteiraFactory<BancoBradesco>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacao))
-                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacao);
+            if (!CarteiraFactory<BancoBradesco>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacaoPadrao))
+                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacaoPadrao);
 
             contaBancaria.FormatarDados("ATÉ O VENCIMENTO EM QUALQUER BANCO. APÓS O VENCIMENTO SOMENTE NO BRADESCO.", 7);
 
@@ -40,13 +40,13 @@ namespace Boleto2Net
 
         public void FormataNossoNumero(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoBradesco>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao);
+            var carteira = CarteiraFactory<BancoBradesco>.ObterCarteira(boleto.CarteiraComVariacao);
             carteira.FormataNossoNumero(boleto);
         }
 
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoBradesco>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao);
+            var carteira = CarteiraFactory<BancoBradesco>.ObterCarteira(boleto.CarteiraComVariacao);
             return carteira.FormataCodigoBarraCampoLivre(boleto);
         }
 
@@ -155,14 +155,13 @@ namespace Boleto2Net
                 boleto.NumeroControleParticipante = registro.Substring(37, 25);
 
                 //Carteira (no arquivo retorno, vem com 1 caracter. Ajustamos para 2 caracteres, como no manual do Bradesco.
-                var contaBancaria = boleto.Banco.Cedente.ContaBancaria;
-                contaBancaria.Carteira = registro.Substring(107, 1).PadLeft(2, '0');
-                contaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
+                boleto.Carteira = registro.Substring(107, 1).PadLeft(2, '0');
+                boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
 
                 //Identificação do Título no Banco
                 boleto.NossoNumero = registro.Substring(70, 11); //Sem o DV
                 boleto.NossoNumeroDV = registro.Substring(81, 1); //DV
-                boleto.NossoNumeroFormatado = $"{contaBancaria.Carteira}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
+                boleto.NossoNumeroFormatado = $"{boleto.Carteira}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
 
                 //Identificação de Ocorrência
                 boleto.CodigoOcorrencia = registro.Substring(108, 2);
@@ -254,7 +253,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0013, 007, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0020, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0021, 001, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0022, 003, 0, boleto.Banco.Cedente.ContaBancaria.Carteira, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0022, 003, 0, boleto.Carteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0025, 005, 0, boleto.Banco.Cedente.ContaBancaria.Agencia, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0030, 007, 0, boleto.Banco.Cedente.ContaBancaria.Conta, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0037, 001, 0, boleto.Banco.Cedente.ContaBancaria.DigitoConta, '0');
@@ -369,7 +368,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0341, 006, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0347, 013, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0360, 007, 0, Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0367, 003, 0, boleto.Banco.Cedente.ContaBancaria.Carteira, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0367, 003, 0, boleto.Carteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0370, 005, 0, boleto.Banco.Cedente.ContaBancaria.Agencia, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0375, 007, 0, boleto.Banco.Cedente.ContaBancaria.Conta, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0382, 001, 0, boleto.Banco.Cedente.ContaBancaria.DigitoConta, '0');

--- a/Boleto2.Net/Banco/BancoBrasil.cs
+++ b/Boleto2.Net/Banco/BancoBrasil.cs
@@ -22,8 +22,8 @@ namespace Boleto2Net
         {
             var contaBancaria = Cedente.ContaBancaria;
 
-            if (!CarteiraFactory<BancoBrasil>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacao))
-                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacao);
+            if (!CarteiraFactory<BancoBrasil>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacaoPadrao))
+                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacaoPadrao);
 
             contaBancaria.FormatarDados("PAGÁVEL EM QUALQUER BANCO ATÉ O VENCIMENTO. APÓS, ATUALIZE O BOLETO NO SITE BB.COM.BR", 8);
 
@@ -37,13 +37,13 @@ namespace Boleto2Net
 
         public void FormataNossoNumero(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoBrasil>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao);
+            var carteira = CarteiraFactory<BancoBrasil>.ObterCarteira(boleto.CarteiraComVariacao);
             carteira.FormataNossoNumero(boleto);
         }
 
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoBrasil>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao);
+            var carteira = CarteiraFactory<BancoBrasil>.ObterCarteira(boleto.CarteiraComVariacao);
             return carteira.FormataCodigoBarraCampoLivre(boleto);
         }
 
@@ -343,8 +343,8 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 014, 0, Cedente.CPFCNPJ, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliDireita______, 0033, 009, 0, Cedente.Codigo, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0042, 004, 0, "0014", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0046, 002, 0, Cedente.ContaBancaria.Carteira, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0048, 003, 0, Cedente.ContaBancaria.VariacaoCarteira, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0046, 002, 0, Cedente.ContaBancaria.CarteiraPadrao, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0048, 003, 0, Cedente.ContaBancaria.VariacaoCarteiraPadrao, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0051, 002, 0, string.Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0053, 005, 0, Cedente.ContaBancaria.Agencia, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0058, 001, 0, Cedente.ContaBancaria.DigitoAgencia, ' ');
@@ -389,8 +389,8 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0019, 015, 0, Cedente.CPFCNPJ, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliDireita______, 0034, 009, 0, Cedente.Codigo, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0043, 004, 0, "0014", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0047, 002, 0, Cedente.ContaBancaria.Carteira, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0049, 003, 0, Cedente.ContaBancaria.VariacaoCarteira, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0047, 002, 0, Cedente.ContaBancaria.CarteiraPadrao, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0049, 003, 0, Cedente.ContaBancaria.VariacaoCarteiraPadrao, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0052, 002, 0, string.Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0054, 005, 0, Cedente.ContaBancaria.Agencia, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0059, 001, 0, Cedente.ContaBancaria.DigitoAgencia, ' ');
@@ -432,8 +432,8 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0036, 001, 0, boleto.Banco.Cedente.ContaBancaria.DigitoConta, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0037, 001, 0, string.Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0038, 020, 0, boleto.NossoNumero, ' ');
-                var tipoCarteira = (int)boleto.Banco.Cedente.ContaBancaria.TipoCarteira;
-                if ((boleto.Banco.Cedente.ContaBancaria.Carteira == "17") & (tipoCarteira == 1))
+                var tipoCarteira = (int)boleto.TipoCarteira;
+                if ((boleto.Carteira == "17") & (tipoCarteira == 1))
                     tipoCarteira = 7; // Informar 7 – para carteira 17 modalidade Simples.
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0058, 001, 0, tipoCarteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0059, 001, 0, (int)boleto.Banco.Cedente.ContaBancaria.TipoFormaCadastramento, '0');
@@ -693,10 +693,10 @@ namespace Boleto2Net
                 else
                     reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0088, 001, 0, string.Empty, 'A');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0089, 003, 0, string.Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0092, 003, 0, boleto.Banco.Cedente.ContaBancaria.VariacaoCarteira, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0092, 003, 0, boleto.VariacaoCarteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0095, 001, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0096, 006, 0, "0", '0');
-                switch (boleto.Banco.Cedente.ContaBancaria.TipoCarteira)
+                switch (boleto.TipoCarteira)
                 {
                     case TipoCarteira.CarteiraCobrancaSimples:
                         reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0102, 005, 0, string.Empty, ' ');
@@ -711,9 +711,9 @@ namespace Boleto2Net
                         reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0102, 005, 0, "08VDR", ' ');
                         break;
                     default:
-                        throw new Exception("Tipo de carteira não suportada: (" + boleto.Banco.Cedente.ContaBancaria.TipoCarteira + ").");
+                        throw new Exception("Tipo de carteira não suportada: (" + boleto.TipoCarteira + ").");
                 }
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0107, 002, 0, boleto.Banco.Cedente.ContaBancaria.Carteira, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0107, 002, 0, boleto.Carteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0109, 002, 0, "01", ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0111, 010, 0, boleto.NumeroDocumento, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAA___________, 0121, 006, 0, boleto.DataVencimento, ' ');
@@ -851,21 +851,21 @@ namespace Boleto2Net
                 boleto.NumeroControleParticipante = registro.Substring(38, 25);
 
                 //Carteira
-                boleto.Banco.Cedente.ContaBancaria.Carteira = registro.Substring(106, 2);
-                boleto.Banco.Cedente.ContaBancaria.VariacaoCarteira = registro.Substring(091, 3);
+                boleto.Carteira = registro.Substring(106, 2);
+                boleto.VariacaoCarteira = registro.Substring(091, 3);
                 switch (registro.Substring(80, 1))
                 {
                     case "2":
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaVinculada;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaVinculada;
                         break;
                     case "4":
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaDescontada;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaDescontada;
                         break;
                     case "8":
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaVendor;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaVendor;
                         break;
                     default:
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
                         break;
                 }
 

--- a/Boleto2.Net/Banco/BancoCaixa.cs
+++ b/Boleto2.Net/Banco/BancoCaixa.cs
@@ -23,8 +23,8 @@ namespace Boleto2Net
         public void FormataCedente()
         {
             var contaBancaria = Cedente.ContaBancaria;
-            if (contaBancaria.CarteiraComVariacao != "SIG14")
-                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.Carteira);
+            if (!CarteiraFactory<BancoCaixa>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacaoPadrao))
+                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacaoPadrao);
 
             var codigoCedente = Cedente.Codigo;
             Cedente.Codigo = codigoCedente.Length <= 6 ? codigoCedente.PadLeft(6, '0') : throw Boleto2NetException.CodigoCedenteInvalido(codigoCedente, 6);
@@ -43,13 +43,13 @@ namespace Boleto2Net
 
         public void FormataNossoNumero(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoCaixa>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.Carteira);
+            var carteira = CarteiraFactory<BancoCaixa>.ObterCarteira(boleto.Carteira);
             carteira.FormataNossoNumero(boleto);
         }
 
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoCaixa>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.Carteira);
+            var carteira = CarteiraFactory<BancoCaixa>.ObterCarteira(boleto.Carteira);
             return carteira.FormataCodigoBarraCampoLivre(boleto);
         }
 
@@ -255,7 +255,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0030, 008, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0038, 003, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0041, 017, 0, boleto.NossoNumero, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0058, 001, 0, (int)boleto.Banco.Cedente.ContaBancaria.TipoCarteira, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0058, 001, 0, (int)boleto.TipoCarteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0059, 001, 0, (int)boleto.Banco.Cedente.ContaBancaria.TipoFormaCadastramento, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0060, 001, 0, "2", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0061, 001, 0, (int)boleto.Banco.Cedente.ContaBancaria.TipoImpressaoBoleto, '0');
@@ -498,17 +498,17 @@ namespace Boleto2Net
                 boleto.NumeroControleParticipante = registro.Substring(105, 25);
 
                 //Carteira
-                boleto.Banco.Cedente.ContaBancaria.Carteira = registro.Substring(57, 1);
-                switch (boleto.Banco.Cedente.ContaBancaria.Carteira)
+                boleto.Carteira = registro.Substring(57, 1);
+                switch (boleto.Carteira)
                 {
                     case "3":
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaCaucionada;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaCaucionada;
                         break;
                     case "4":
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaDescontada;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaDescontada;
                         break;
                     default:
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
                         break;
                 }
 

--- a/Boleto2.Net/Banco/BancoItau.cs
+++ b/Boleto2.Net/Banco/BancoItau.cs
@@ -23,8 +23,8 @@ namespace Boleto2Net
         {
             var contaBancaria = Cedente.ContaBancaria;
 
-            if (!CarteiraFactory<BancoItau>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacao))
-                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacao);
+            if (!CarteiraFactory<BancoItau>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacaoPadrao))
+                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacaoPadrao);
 
             contaBancaria.FormatarDados("ATÉ O VENCIMENTO EM QUALQUER BANCO. APÓS O VENCIMENTO SOMENTE NO ITAÚ.", 5);
 
@@ -37,13 +37,13 @@ namespace Boleto2Net
 
         public void FormataNossoNumero(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoItau>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao);
+            var carteira = CarteiraFactory<BancoItau>.ObterCarteira(boleto.CarteiraComVariacao);
             carteira.FormataNossoNumero(boleto);
         }
 
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoItau>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao);
+            var carteira = CarteiraFactory<BancoItau>.ObterCarteira(boleto.CarteiraComVariacao);
             return carteira.FormataCodigoBarraCampoLivre(boleto);
         }
 
@@ -158,19 +158,18 @@ namespace Boleto2Net
                 boleto.NumeroControleParticipante = registro.Substring(37, 25);
 
                 //Carteira
-                var contaBancaria = boleto.Banco.Cedente.ContaBancaria;
-                contaBancaria.Carteira = registro.Substring(107, 1).PadLeft(2, '0');
-                contaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
+                boleto.Carteira = registro.Substring(82, 3);
+                boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
 
                 //Identificação do Título no Banco
-                boleto.NossoNumero = registro.Substring(70, 11); //Sem o DV
-                boleto.NossoNumeroDV = registro.Substring(81, 1); //DV
-                boleto.NossoNumeroFormatado = $"{contaBancaria.Carteira}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
+                boleto.NossoNumero = registro.Substring(85, 8);
+                boleto.NossoNumeroDV = registro.Substring(93, 1); //DV
+                boleto.NossoNumeroFormatado = $"{boleto.Carteira}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
 
                 //Identificação de Ocorrência
                 boleto.CodigoOcorrencia = registro.Substring(108, 2);
                 boleto.DescricaoOcorrencia = DescricaoOcorrenciaCnab400(boleto.CodigoOcorrencia);
-                boleto.CodigoOcorrenciaAuxiliar = registro.Substring(318, 10);
+                boleto.CodigoOcorrenciaAuxiliar = registro.Substring(377, 8);
 
                 //Número do Documento
                 boleto.NumeroDocumento = registro.Substring(116, 10);
@@ -263,10 +262,10 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0038, 025, 0, boleto.NumeroControleParticipante, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0063, 008, 0, boleto.NossoNumero, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0071, 013, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0084, 003, 0, boleto.Banco.Cedente.ContaBancaria.Carteira, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0084, 003, 0, boleto.Carteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0087, 021, 0, Empty, ' ');
 
-                switch (boleto.Banco.Cedente.ContaBancaria.Carteira)
+                switch (boleto.Carteira)
                 {
                     case "109":
                         reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 108, 001, 0, "I", ' ');

--- a/Boleto2.Net/Banco/BancoSantander.cs
+++ b/Boleto2.Net/Banco/BancoSantander.cs
@@ -23,8 +23,8 @@ namespace Boleto2Net
         {
             var contaBancaria = Cedente.ContaBancaria;
 
-            if (!CarteiraFactory<BancoSantander>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacao))
-                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacao);
+            if (!CarteiraFactory<BancoSantander>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacaoPadrao))
+                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacaoPadrao);
 
             contaBancaria.FormatarDados("ATÉ O VENCIMENTO EM QUALQUER BANCO. APÓS O VENCIMENTO SOMENTE NO SANTANDER.", digitosConta: 9);
 
@@ -40,13 +40,13 @@ namespace Boleto2Net
 
         public void FormataNossoNumero(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoSantander>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao);
+            var carteira = CarteiraFactory<BancoSantander>.ObterCarteira(boleto.CarteiraComVariacao);
             carteira.FormataNossoNumero(boleto);
         }
 
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoSantander>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao);
+            var carteira = CarteiraFactory<BancoSantander>.ObterCarteira(boleto.CarteiraComVariacao);
             return carteira.FormataCodigoBarraCampoLivre(boleto);
         }
 
@@ -162,9 +162,9 @@ namespace Boleto2Net
                 boleto.NumeroControleParticipante = registro.Substring(105, 25);
 
                 //Carteira
-                boleto.Banco.Cedente.ContaBancaria.Carteira = registro.Substring(57, 1);
-                if (boleto.Banco.Cedente.ContaBancaria.Carteira == "1")
-                    boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
+                boleto.Carteira = registro.Substring(57, 1);
+                if (boleto.Carteira == "1")
+                    boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
 
                 //Identificação do Título no Banco
                 boleto.NossoNumero = registro.Substring(50, 6);
@@ -331,11 +331,11 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0043, 002, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0045, 013, 0, boleto.NossoNumero+boleto.NossoNumeroDV, '0');
 
-                if (boleto.Banco.Cedente.ContaBancaria.TipoCarteira == TipoCarteira.CarteiraCobrancaSimples)
+                if (boleto.TipoCarteira == TipoCarteira.CarteiraCobrancaSimples)
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 058, 001, 0, "5", '0');
-                if (boleto.Banco.Cedente.ContaBancaria.TipoCarteira == TipoCarteira.CarteiraCobrancaCaucionada)
+                if (boleto.TipoCarteira == TipoCarteira.CarteiraCobrancaCaucionada)
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 058, 001, 0, "6", '0');
-                if (boleto.Banco.Cedente.ContaBancaria.TipoCarteira == TipoCarteira.CarteiraCobrancaDescontada)
+                if (boleto.TipoCarteira == TipoCarteira.CarteiraCobrancaDescontada)
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 058, 001, 0, "4", '0');
 
                 if (boleto.Banco.Cedente.ContaBancaria.TipoFormaCadastramento == TipoFormaCadastramento.ComRegistro)

--- a/Boleto2.Net/Banco/BancoSicoob.cs
+++ b/Boleto2.Net/Banco/BancoSicoob.cs
@@ -30,8 +30,8 @@ namespace Boleto2Net
         {
             var contaBancaria = Cedente.ContaBancaria;
 
-            if (!CarteiraFactory<BancoSicoob>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacao))
-                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacao);
+            if (!CarteiraFactory<BancoSicoob>.CarteiraEstaImplementada(contaBancaria.CarteiraComVariacaoPadrao))
+                throw Boleto2NetException.CarteiraNaoImplementada(contaBancaria.CarteiraComVariacaoPadrao);
 
             var codigoCedente = Cedente.Codigo;
             if (Cedente.CodigoDV == Empty)
@@ -50,13 +50,13 @@ namespace Boleto2Net
 
         public void FormataNossoNumero(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoSicoob>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao);
+            var carteira = CarteiraFactory<BancoSicoob>.ObterCarteira(boleto.CarteiraComVariacao);
             carteira.FormataNossoNumero(boleto);
         }
 
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            var carteira = CarteiraFactory<BancoSicoob>.ObterCarteira(boleto.Banco.Cedente.ContaBancaria.CarteiraComVariacao);
+            var carteira = CarteiraFactory<BancoSicoob>.ObterCarteira(boleto.CarteiraComVariacao);
             return carteira.FormataCodigoBarraCampoLivre(boleto);
         }
 
@@ -273,11 +273,11 @@ namespace Boleto2Net
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0047, 001, 0, boleto.NossoNumeroDV, '0');
                 }
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0048, 002, 0, "01", '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0050, 002, 0, boleto.Banco.Cedente.ContaBancaria.VariacaoCarteira, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0050, 002, 0, boleto.VariacaoCarteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0052, 001, 0, "4", '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0053, 005, 0, Empty, ' ');
 
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0058, 001, 0, boleto.Banco.Cedente.ContaBancaria.Carteira, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0058, 001, 0, boleto.Carteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0059, 001, 0, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0060, 001, 0, " ", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0061, 001, 0, (int)boleto.Banco.Cedente.ContaBancaria.TipoImpressaoBoleto, '0');
@@ -551,7 +551,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0102, 004, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0106, 001, 0, (int)boleto.Banco.Cedente.ContaBancaria.TipoImpressaoBoleto, '0');
 
-                switch (boleto.Banco.Cedente.ContaBancaria.TipoCarteira)
+                switch (boleto.TipoCarteira)
                 {
                     case TipoCarteira.CarteiraCobrancaSimples:
                         reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0107, 002, 0, "01", ' '); // Simples com Registro
@@ -560,7 +560,7 @@ namespace Boleto2Net
                         reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0107, 002, 0, "03", ' '); // Garantida Caucionada
                         break;
                     default:
-                        throw new Exception("Tipo de carteira não suportada: (" + boleto.Banco.Cedente.ContaBancaria.TipoCarteira.ToString() + ").");
+                        throw new Exception("Tipo de carteira não suportada: (" + boleto.TipoCarteira.ToString() + ").");
                 }
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0109, 002, 0, "01", ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0111, 010, 0, boleto.NumeroDocumento, ' ');
@@ -648,14 +648,14 @@ namespace Boleto2Net
                 boleto.NumeroControleParticipante = registro.Substring(105, 25);
 
                 //Carteira
-                boleto.Banco.Cedente.ContaBancaria.Carteira = registro.Substring(57, 1);
-                switch (boleto.Banco.Cedente.ContaBancaria.Carteira)
+                boleto.Carteira = registro.Substring(57, 1);
+                switch (boleto.Carteira)
                 {
                     case "3":
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaCaucionada;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaCaucionada;
                         break;
                     default:
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
                         break;
                 }
 
@@ -747,17 +747,17 @@ namespace Boleto2Net
                 boleto.NumeroControleParticipante = registro.Substring(37, 25);
 
                 //Carteira
-                boleto.Banco.Cedente.ContaBancaria.Carteira = registro.Substring(106, 2);
-                switch (boleto.Banco.Cedente.ContaBancaria.Carteira)
+                boleto.Carteira = registro.Substring(106, 2);
+                switch (boleto.Carteira)
                 {
                     case "01":
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
                         break;
                     case "03":
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaCaucionada;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaCaucionada;
                         break;
                     default:
-                        boleto.Banco.Cedente.ContaBancaria.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
+                        boleto.TipoCarteira = TipoCarteira.CarteiraCobrancaSimples;
                         break;
                 }
 

--- a/Boleto2.Net/Banco/Carteiras/BancoBradesco/BancoBradescoCarteira09.cs
+++ b/Boleto2.Net/Banco/Carteiras/BancoBradesco/BancoBradescoCarteira09.cs
@@ -25,14 +25,14 @@ namespace Boleto2Net
                 throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve conter 11 dígitos.");
 
             boleto.NossoNumero = boleto.NossoNumero.PadLeft(11, '0');
-            boleto.NossoNumeroDV = (boleto.Banco.Cedente.ContaBancaria.Carteira + boleto.NossoNumero).CalcularDVBradesco();
-            boleto.NossoNumeroFormatado = $"{boleto.Banco.Cedente.ContaBancaria.Carteira.PadLeft(3, '0')}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
+            boleto.NossoNumeroDV = (boleto.Carteira + boleto.NossoNumero).CalcularDVBradesco();
+            boleto.NossoNumeroFormatado = $"{boleto.Carteira.PadLeft(3, '0')}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
         }
 
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
             var contaBancaria = boleto.Banco.Cedente.ContaBancaria;
-            return $"{contaBancaria.Agencia}{contaBancaria.Carteira}{boleto.NossoNumero}{contaBancaria.Conta}{"0"}";
+            return $"{contaBancaria.Agencia}{boleto.Carteira}{boleto.NossoNumero}{contaBancaria.Conta}{"0"}";
         }
     }
 }

--- a/Boleto2.Net/Banco/Carteiras/BancoBrasil/BancoBrasilCarteira11_019.cs
+++ b/Boleto2.Net/Banco/Carteiras/BancoBrasil/BancoBrasilCarteira11_019.cs
@@ -31,7 +31,7 @@ namespace Boleto2Net
 
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            return $"000000{boleto.NossoNumero}{boleto.Banco.Cedente.ContaBancaria.Carteira}";
+            return $"000000{boleto.NossoNumero}{boleto.Carteira}";
         }
     }
 }

--- a/Boleto2.Net/Banco/Carteiras/BancoBrasil/BancoBrasilCarteira17_019.cs
+++ b/Boleto2.Net/Banco/Carteiras/BancoBrasil/BancoBrasilCarteira17_019.cs
@@ -44,7 +44,7 @@ namespace Boleto2Net
 
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            return $"000000{boleto.NossoNumero}{boleto.Banco.Cedente.ContaBancaria.Carteira}";
+            return $"000000{boleto.NossoNumero}{boleto.Carteira}";
         }
     }
 }

--- a/Boleto2.Net/Banco/Carteiras/BancoItau/BancoItauCarteira109.cs
+++ b/Boleto2.Net/Banco/Carteiras/BancoItau/BancoItauCarteira109.cs
@@ -24,13 +24,13 @@ namespace Boleto2Net
                 throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve conter 8 dígitos.");
 
             boleto.NossoNumero = boleto.NossoNumero.PadLeft(8, '0');
-            boleto.NossoNumeroDV = (boleto.Banco.Cedente.ContaBancaria.Agencia + boleto.Banco.Cedente.ContaBancaria.Conta + boleto.Banco.Cedente.ContaBancaria.Carteira + boleto.NossoNumero).CalcularDVItau();
-            boleto.NossoNumeroFormatado = $"{boleto.Banco.Cedente.ContaBancaria.Carteira}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
+            boleto.NossoNumeroDV = (boleto.Banco.Cedente.ContaBancaria.Agencia + boleto.Banco.Cedente.ContaBancaria.Conta + boleto.Carteira + boleto.NossoNumero).CalcularDVItau();
+            boleto.NossoNumeroFormatado = $"{boleto.Carteira}/{boleto.NossoNumero}-{boleto.NossoNumeroDV}";
         }
 
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            return $"{boleto.Banco.Cedente.ContaBancaria.Carteira}{boleto.NossoNumero}{boleto.NossoNumeroDV}{boleto.Banco.Cedente.ContaBancaria.Agencia}{boleto.Banco.Cedente.ContaBancaria.Conta}{boleto.Banco.Cedente.ContaBancaria.DigitoConta}000";
+            return $"{boleto.Carteira}{boleto.NossoNumero}{boleto.NossoNumeroDV}{boleto.Banco.Cedente.ContaBancaria.Agencia}{boleto.Banco.Cedente.ContaBancaria.Conta}{boleto.Banco.Cedente.ContaBancaria.DigitoConta}000";
         }
     }
 }

--- a/Boleto2.Net/Banco/Carteiras/BancoSicoob/BancoSincoobCarteira1.cs
+++ b/Boleto2.Net/Banco/Carteiras/BancoSicoob/BancoSincoobCarteira1.cs
@@ -36,7 +36,7 @@ namespace Boleto2Net
         {
             var cedente = boleto.Banco.Cedente;
             var contaBancaria = cedente.ContaBancaria;
-            return $"{contaBancaria.Carteira}{contaBancaria.Agencia}{contaBancaria.VariacaoCarteira}{cedente.Codigo}{cedente.CodigoDV}{boleto.NossoNumero}{boleto.NossoNumeroDV}001";
+            return $"{boleto.Carteira}{contaBancaria.Agencia}{boleto.VariacaoCarteira}{cedente.Codigo}{cedente.CodigoDV}{boleto.NossoNumero}{boleto.NossoNumeroDV}001";
         }
     }
 }

--- a/Boleto2.Net/Boleto/Boleto.cs
+++ b/Boleto2.Net/Boleto/Boleto.cs
@@ -8,6 +8,13 @@ namespace Boleto2Net
     [Browsable(false)]
     public class Boleto
     {
+        public Boleto(IBanco banco)
+        {
+            Banco = banco;
+            Carteira = banco.Cedente.ContaBancaria.CarteiraPadrao;
+            VariacaoCarteira = banco.Cedente.ContaBancaria.VariacaoCarteiraPadrao;
+            TipoCarteira = banco.Cedente.ContaBancaria.TipoCarteiraPadrao;
+        }
         public int CodigoMoeda { get; set; } = 9;
         public string EspecieMoeda { get; set; } = "R$";
         public int QuantidadeMoeda { get; set; } = 0;
@@ -18,6 +25,11 @@ namespace Boleto2Net
         public string NossoNumero { get; set; } = string.Empty;
         public string NossoNumeroDV { get; set; } = string.Empty;
         public string NossoNumeroFormatado { get; set; } = string.Empty;
+
+        public TipoCarteira TipoCarteira { get; set; } = TipoCarteira.CarteiraCobrancaSimples;
+        public string Carteira { get; set; } = string.Empty;
+        public string VariacaoCarteira { get; set; } = string.Empty;
+        public string CarteiraComVariacao => string.IsNullOrEmpty(Carteira) || string.IsNullOrEmpty(VariacaoCarteira) ? $"{Carteira}{VariacaoCarteira}" : $"{Carteira}/{VariacaoCarteira}";
 
         public DateTime DataProcessamento { get; set; } = DateTime.Now;
         public DateTime DataEmissao { get; set; } = DateTime.Now;

--- a/Boleto2.Net/Boleto/ContaBancaria.cs
+++ b/Boleto2.Net/Boleto/ContaBancaria.cs
@@ -5,19 +5,20 @@ namespace Boleto2Net
 {
     public class ContaBancaria
     {
+        public TipoCarteira TipoCarteiraPadrao { get; set; } = TipoCarteira.CarteiraCobrancaSimples;
+        public string CarteiraPadrao { get; set; } = string.Empty;
+        public string VariacaoCarteiraPadrao { get; set; } = string.Empty;
+        public string CarteiraComVariacaoPadrao => string.IsNullOrEmpty(CarteiraPadrao) || string.IsNullOrEmpty(VariacaoCarteiraPadrao) ? $"{CarteiraPadrao}{VariacaoCarteiraPadrao}" : $"{CarteiraPadrao}/{VariacaoCarteiraPadrao}";
+
         public string Agencia { get; set; } = Empty;
         public string DigitoAgencia { get; set; } = Empty;
         public string Conta { get; set; } = Empty;
         public string DigitoConta { get; set; } = Empty;
         public string OperacaoConta { get; set; } = Empty;
-        public string Carteira { get; set; } = Empty;
-        public string VariacaoCarteira { get; set; } = Empty;
-        public TipoCarteira TipoCarteira { get; set; } = TipoCarteira.CarteiraCobrancaSimples;
         public TipoFormaCadastramento TipoFormaCadastramento { get; set; } = TipoFormaCadastramento.ComRegistro;
         public TipoImpressaoBoleto TipoImpressaoBoleto { get; set; } = TipoImpressaoBoleto.Empresa;
         public TipoDocumento TipoDocumento { get; set; } = TipoDocumento.Tradicional;
         public string LocalPagamento { get; set; } = "PAGÁVEL EM QUALQUER BANCO ATÉ A DATA DE VENCIMENTO.";
-        public string CarteiraComVariacao => IsNullOrEmpty(Carteira) || IsNullOrEmpty(VariacaoCarteira) ? $"{Carteira}{VariacaoCarteira}" : $"{Carteira}/{VariacaoCarteira}";
         public int CodigoBancoCorrespondente { get; set; }
         public string NossoNumeroBancoCorrespondente { get; set; }
 

--- a/Boleto2.Net/Boleto2NetProxy.cs
+++ b/Boleto2.Net/Boleto2NetProxy.cs
@@ -37,8 +37,13 @@ namespace Boleto2Net
         //      1.26 - Itaú - Carteira 109 Homologada
         // Junho/2017
         //      1.30 - Correções no método FormataCedente e suas exceções - Quantidade de dígitos da conta e código do cedente
+        //      1.31 - Correções na leitura do retorno do Itaú
+        //      1.40 - Inclusao das propriedades Carteira, VariacaoCarteira, TipoCarteira também na classe Boleto.
+        //             As propriedades que já existiam na classe ContaCorrente, foram renomeadas para CarteiraPadrao, VariacaoCarteiraPadrao, TipoCarteiraPadrao
+        //             A classe Boleto passou a ter um construtor obrigatorio, onde recebe um objeto Banco, e já prepara as 3 propriedades com o padrão definido.
+        //             Alteração foi necessária pois existem retornos com boletos em diferentes carteiras, e do modo que estava, aceitava apenas uma carteira para toda a lista de boletos.
 
-        readonly public string Versao = "1.30";
+        readonly public string Versao = "1.40c";
 
         private Boletos boletos = new Boletos();
         public int quantidadeBoletos { get { return boletos.Count; } }
@@ -124,9 +129,9 @@ namespace Boleto2Net
                             OperacaoConta = operacaoConta,
                             Conta = conta,
                             DigitoConta = digitoConta,
-                            Carteira = carteira,
-                            VariacaoCarteira = variacaoCarteira,
-                            TipoCarteira = (TipoCarteira)tipoCarteira,
+                            CarteiraPadrao = carteira,
+                            VariacaoCarteiraPadrao = variacaoCarteira,
+                            TipoCarteiraPadrao = (TipoCarteira)tipoCarteira,
                             TipoFormaCadastramento = (TipoFormaCadastramento)tipoFormaCadastramento,
                             TipoImpressaoBoleto = (TipoImpressaoBoleto)tipoImpressaoBoleto,
                             TipoDocumento = (TipoDocumento)tipoDocumento
@@ -219,10 +224,7 @@ namespace Boleto2Net
                     mensagemErro = "Realize o setup da cobrança antes de executar este método.";
                     return false;
                 }
-                boleto = new Boleto
-                {
-                    Banco = boletos.Banco
-                };
+                boleto = new Boleto(boletos.Banco);
                 return true;
             }
             catch (Exception ex)

--- a/Boleto2.Net/BoletoImpressao/BoletoBancario.cs
+++ b/Boleto2.Net/BoletoImpressao/BoletoBancario.cs
@@ -437,7 +437,7 @@ namespace Boleto2Net
                 .Replace("@ESPECIEDOCUMENTO", Boleto.EspecieDocumento.ToString())
                 .Replace("@DATAPROCESSAMENTO", Boleto.DataProcessamento.ToString("dd/MM/yyyy"))
                 .Replace("@NOSSONUMERO", Boleto.NossoNumeroFormatado)
-                .Replace("@CARTEIRA", Boleto.Banco.Cedente.ContaBancaria.Carteira)
+                .Replace("@CARTEIRA", Boleto.Carteira)
                 .Replace("@ESPECIE", Boleto.EspecieMoeda)
                 .Replace("@QUANTIDADE", (Boleto.QuantidadeMoeda == 0 ? "" : Boleto.QuantidadeMoeda.ToString()))
                 .Replace("@VALORDOCUMENTO", Boleto.ValorMoeda)

--- a/Boleto2.Net/Como Implementar um novo Banco ou Carteira.txt
+++ b/Boleto2.Net/Como Implementar um novo Banco ou Carteira.txt
@@ -92,8 +92,8 @@
 	Controle do Participante
 		boleto.NumeroControleParticipante
 	Carteira
-		boleto.Banco.Cedente.ContaBancaria.Carteira
-		boleto.Banco.Cedente.ContaBancaria.TipoCarteira (Padrão: CarteiraCobrancaSimples)
+		boleto.Carteira
+		boleto.TipoCarteira (Padrão: CarteiraCobrancaSimples)
 	Identificação do Título no Banco
 		boleto.NossoNumero (Sem o dígito)
 		boleto.NossoNumeroDV (Apenas o dígito)


### PR DESCRIPTION
1 - Inclusão das propriedades Carteira, VariacaoCarteira, TipoCarteira também na classe Boleto.

2 - As propriedades que já existiam na classe ContaCorrente, foram renomeadas para CarteiraPadrao, VariacaoCarteiraPadrao, TipoCarteiraPadrao

3 - A classe Boleto passou a ter um construtor obrigatório, onde recebe um objeto Banco, e já prepara as 3 propriedades com o padrão definido.

**Obs: Alteração foi necessária pois existem retornos com boletos em diferentes carteiras, e do modo que estava, aceitava apenas uma carteira para toda a lista de boletos.**

Também foi feita uma correção na leitura do arquivo retorno do Itau (posição do registro retorno para os campos: NossoNumero-Dv e Códigos Auxiliares da Operação.)
