### PR TITLE
Alterações de Remessa e Retorno dos Bancos SICOOB e BRADESCO

### DIFF
--- a/Boleto2.Net/Banco/BancoBradesco.cs
+++ b/Boleto2.Net/Banco/BancoBradesco.cs
@@ -578,7 +578,8 @@ namespace Boleto2Net
 
                 //Dados Sacado
                 boleto.Sacado = new Sacado();
-                boleto.Sacado.CPFCNPJ = registro.Substring(133, 15);
+                string str = registro.Substring(133, 15);
+                boleto.Sacado.CPFCNPJ = str.Substring(str.Length - 14, 14);
                 boleto.Sacado.Nome = registro.Substring(148, 40);
 
 

--- a/Boleto2.Net/Banco/BancoSicoob.cs
+++ b/Boleto2.Net/Banco/BancoSicoob.cs
@@ -287,7 +287,7 @@ namespace Boleto2Net
 
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0058, 001, 0, boleto.Carteira, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0059, 001, 0, "0", '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0060, 001, 0, " ", '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0060, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0061, 001, 0, (int)boleto.Banco.Cedente.ContaBancaria.TipoImpressaoBoleto, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0062, 001, 0, (int)boleto.Banco.Cedente.ContaBancaria.TipoImpressaoBoleto, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0063, 015, 0, boleto.NumeroDocumento, ' ');
@@ -334,6 +334,12 @@ namespace Boleto2Net
                     case TipoCodigoProtesto.ProtestarDiasCorridos:
                         reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 001, 0, 1, '0');
                         break;
+                    case TipoCodigoProtesto.ProtestarDiasUteis:
+                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 001, 0, 2, '0');
+                        break;
+                    case TipoCodigoProtesto.NaoProtestar:
+                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 001, 0, 3, '0');
+                        break;
                     default:
                         reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 001, 0, 0, '0');
                         break;
@@ -351,7 +357,7 @@ namespace Boleto2Net
                         reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0224, 001, 0, 0, '0');
                         break;
                 }
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0225, 003, 0, boleto.DiasBaixaDevolucao, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0225, 003, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0228, 002, 0, "09", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0230, 010, 2, "0", '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0240, 001, 0, Empty, ' ');
@@ -745,7 +751,8 @@ namespace Boleto2Net
 
                 //Dados Sacado
                 boleto.Sacado = new Sacado();
-                boleto.Sacado.CPFCNPJ = registro.Substring(133, 15);
+                string str = registro.Substring(133, 15);
+                boleto.Sacado.CPFCNPJ = str.Substring(str.Length - 14, 14);
                 boleto.Sacado.Nome = registro.Substring(148, 40);
 
 


### PR DESCRIPTION
-mudança na posição 221 do registro P, alteracao do case do codigo de protesto (sicoob);
-mudança na posicao 225 tem q passar brancos ao inves de '0', em dias pra devolucao (sicoob);
-corrigido no retorno do CNAB dados do sacado o CNPJ (bradesco e sicoob), por causa da validação de 14 caracteres;