### PR TITLE
melhoria na alteracao para retorno com  multiplas carteiras. sobrecar…

### DIFF
--- a/Boleto2.Net/Arquivo/ArquivoRetorno.cs
+++ b/Boleto2.Net/Arquivo/ArquivoRetorno.cs
@@ -12,12 +12,15 @@ namespace Boleto2Net
         public Boletos Boletos { get; set; } = new Boletos();
         public DateTime? DataGeracao { get; set; }
         public int? NumeroSequencial { get; set; }
+
+        private bool _ignorarCarteiraBoleto = false;
         #region Construtores
 
-        public ArquivoRetorno(IBanco banco, TipoArquivo tipoArquivo)
+        public ArquivoRetorno(IBanco banco, TipoArquivo tipoArquivo, bool variasCarteiras = false)
         {
             Banco = banco;
             TipoArquivo = tipoArquivo;
+            _ignorarCarteiraBoleto = variasCarteiras;
         }
 
         /// <summary>
@@ -126,7 +129,7 @@ namespace Boleto2Net
             if (tipoRegistro == "3" & tipoSegmento == "T")
             {
                 // Segmento T - Indica um novo boleto
-                var boleto = new Boleto(this.Banco);
+                var boleto = new Boleto(this.Banco, _ignorarCarteiraBoleto);
                 Banco.LerDetalheRetornoCNAB240SegmentoT(ref boleto, registro);
                 Boletos.Add(boleto);
                 return;
@@ -178,7 +181,7 @@ namespace Boleto2Net
             Boleto boleto;
             if (novoBoleto)
             {
-                boleto = new Boleto(this.Banco);
+                boleto = new Boleto(this.Banco, _ignorarCarteiraBoleto);
             }
             else
             {

--- a/Boleto2.Net/Boleto/Boleto.cs
+++ b/Boleto2.Net/Boleto/Boleto.cs
@@ -11,14 +11,23 @@ namespace Boleto2Net
         public Boleto(IBanco banco)
         {
             Banco = banco;
-            //alteração evita erro ao processar retorno sem dados da carteira, e somente informando o banco (múltiplas carteiras no arquivo de retorno)
-            if (banco.Cedente != null)
+            Carteira = banco.Cedente.ContaBancaria.CarteiraPadrao;
+            VariacaoCarteira = banco.Cedente.ContaBancaria.VariacaoCarteiraPadrao;
+            TipoCarteira = banco.Cedente.ContaBancaria.TipoCarteiraPadrao;
+        }
+
+        public Boleto(IBanco banco, Boolean ignorarCarteira)
+        {
+            Banco = banco;
+            //se o arquivo de retorno for criado par multiplas carteiras, ignora a carteira (para compatibilidade)
+            if (!ignorarCarteira)
             {
                 Carteira = banco.Cedente.ContaBancaria.CarteiraPadrao;
                 VariacaoCarteira = banco.Cedente.ContaBancaria.VariacaoCarteiraPadrao;
                 TipoCarteira = banco.Cedente.ContaBancaria.TipoCarteiraPadrao;
             }
         }
+
         public int CodigoMoeda { get; set; } = 9;
         public string EspecieMoeda { get; set; } = "R$";
         public int QuantidadeMoeda { get; set; } = 0;

--- a/Boleto2.Net/Boleto2.Net.csproj
+++ b/Boleto2.Net/Boleto2.Net.csproj
@@ -28,7 +28,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\..\Recursos\Referencias\Boleto2.Net\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
sobrecarga do construtor de Boleto, que força para forçar o desenvolvedor a infrormar que quer ignorar a carteira. por default, a opção não impacta nas demais implementações , apenas nas chamadas de arquivo retorno.