### PR TITLE
Caixa Economica - Correção Retorno Cnab240 Segmento T

### DIFF
--- a/Boleto2.Net/Banco/BancoCaixa.cs
+++ b/Boleto2.Net/Banco/BancoCaixa.cs
@@ -679,11 +679,11 @@ namespace Boleto2Net
 
                 //Identificação do Título no Banco
                 boleto.NossoNumero = registro.Substring(39, 17);
-                boleto.NossoNumeroDV = "";
-                boleto.NossoNumeroFormatado = boleto.NossoNumero;
+                boleto.NossoNumeroDV = registro.Substring(56, 1);
+                boleto.NossoNumeroFormatado = Format("{0}-{1}", boleto.NossoNumero, boleto.NossoNumeroDV);
 
                 //Identificação de Ocorrência
-                boleto.CodigoOcorrencia = registro.Substring(108, 2);
+                boleto.CodigoOcorrencia = registro.Substring(15, 2);
                 boleto.DescricaoOcorrencia = Cnab.OcorrenciaCnab240(boleto.CodigoOcorrencia);
                 boleto.CodigoOcorrenciaAuxiliar = registro.Substring(213, 10);
 

--- a/Boleto2.Net/Boleto2NetProxy.cs
+++ b/Boleto2.Net/Boleto2NetProxy.cs
@@ -68,8 +68,10 @@ namespace Boleto2Net
         //      1.60 - Ajuste Boleto Padrão Caixa Econônica Federal (Mensagem Fixa Sacado)
         //             Alteração da classe Boleto: Adicionado propriedade para controlar a impressão do código da carteira no boleto
         //             Alteração da classe ContaBancaria: Adicionado propriedade para imprimir mensagem na área de instrução do sacado.
+        // Setembro/2018
+        //      1.61 - Caixa Economica - Correção Retorno CNAB240 Segmento T
 
-        readonly public string Versao = "1.60a";
+        readonly public string Versao = "1.61";
 
         private Boletos boletos = new Boletos();
         public int quantidadeBoletos { get { return boletos.Count; } }


### PR DESCRIPTION
Origem do Problema:
https://github.com/BoletoNet/boleto2net/commit/8d3b0cfac371aaa9d9c06957f887cae3cd4b93fb#r30656221

Após atualizar o código em um cliente, nosso sistema começou a apresentar problemas na leitura do CNAB 240... As posições anteriores (NossoNumero + CodigoOcorrencia) estavam corretas.

Manual Caixa - Campo 13.3T - Posição 40-56 - Nosso Número (Modalidade / Identificação)
boleto.NossoNumeroDV = registro.Substring(56, 1);

Manual Caixa - Campo 13.3T - Posição 57 - DV do Nosso Número do Título
boleto.NossoNumeroFormatado = Format("{0}-{1}",

Manual Caixa - Campo 07.3T - Código de Movimento Retorno Posição 16-17
boleto.CodigoOcorrencia = registro.Substring(15, 2);

