### PR TITLE
Código baixa/devolução e valores totais do registro trailler do lote

### DIFF
--- a/Boleto2.Net/Banco/BancoSicoob.cs
+++ b/Boleto2.Net/Banco/BancoSicoob.cs
@@ -344,18 +344,13 @@ namespace Boleto2Net
                         break;
                 }
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0222, 002, 0, boleto.DiasProtesto, '0');
-                switch (boleto.CodigoBaixaDevolucao)
-                {
-                    case TipoCodigoBaixaDevolucao.NaoBaixarNaoDevolver:
-                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0224, 001, 0, 2, '0');
-                        break;
-                    case TipoCodigoBaixaDevolucao.BaixarDevolver:
-                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0224, 001, 0, 1, '0');
-                        break;
-                    default:
-                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0224, 001, 0, 0, '0');
-                        break;
-                }
+
+                #region
+                //Seq       De      Até     Dig     Dec     Form    Campo/Descrição             Conteudo
+                //38.3P     224     224     001     -       Num     Código p/ Baixa/Devolução   Código para Baixa/Devolução: "0"
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0224, 001, 0, "0", '0');
+                #endregion
+
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0225, 003, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0228, 002, 0, "09", '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0230, 010, 2, "0", '0');
@@ -509,15 +504,15 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0009, 009, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0018, 006, 0, numeroRegistrosNoLote, '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0024, 006, 0, numeroRegistroCobrancaSimples, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0030, 015, 2, valorCobrancaSimples, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0045, 006, 0, numeroRegistroCobrancaVinculada, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0051, 015, 2, valorCobrancaVinculada, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0066, 006, 0, numeroRegistroCobrancaCaucionada, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0072, 015, 2, valorCobrancaCaucionada, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0087, 006, 0, numeroRegistroCobrancaDescontada, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0093, 015, 2, valorCobrancaDescontada, '0');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0108, 008, 0, Empty, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0116, 125, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0030, 017, 2, valorCobrancaSimples, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0047, 006, 0, numeroRegistroCobrancaVinculada, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0053, 017, 2, valorCobrancaVinculada, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0070, 006, 0, numeroRegistroCobrancaCaucionada, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0076, 017, 2, valorCobrancaCaucionada, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0093, 006, 0, numeroRegistroCobrancaDescontada, '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0099, 017, 2, valorCobrancaDescontada, '0');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0116, 008, 0, Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0124, 117, 0, Empty, ' ');
                 reg.CodificarLinha();
                 return reg.LinhaRegistro;
             }


### PR DESCRIPTION
Fizemos a homologação com o Sicoob e durante o processo obtivemos os seguintes erros:

POSICAO: 224 a 224
DESCRICAO: CÓDIGO PARA BAIXA/DEVOLUÇÃO INVÁLIDO
Correção realizada: Sempre enviar "0"
Obs.: Ao questionarmos sobre o erro acima obtivemos a seguinte resposta do Sicoob:
"A posição P(224) sempre deve ser preenchida com zero, é padrão para todos os casos.
Caso o beneficiário deseje realizar a baixa por meio de arquivo de remessa, o mesmo deverá enviar arquivo com a devida instrução no código de movimento remessa (ver layout)."

POSICAO: 99 a 115
DESCRICAO: VALOR TOTAL DOS TITULOS DA COBRANCA DESCONTADA INVÁLIDO PREENCHER COM 0
Correção realizada: Os valores totais no registro trailler do lote são decimal(17,2) "999999999999999,99"

Realizamos as correções de acordo com o que consta no arquivo 'Layouts_para_troca_de_informações.xls'
