### PR TITLE
Possibilita fornecer um NossoNumero gerado previamente (Sicredi)

### DIFF
--- a/Boleto2.Net/Banco/Carteiras/BancoSicredi/BancoSicrediCarteira1.cs
+++ b/Boleto2.Net/Banco/Carteiras/BancoSicredi/BancoSicrediCarteira1.cs
@@ -27,15 +27,29 @@ namespace Boleto2Net
 
         public void FormataNossoNumero(Boleto boleto)
         {
-            var DataDocumento = boleto.DataEmissao.ToString("yy");
-            var nossoNumero = boleto.NossoNumero;
-
-            boleto.NossoNumero = string.Format("{0}2{1}", DataDocumento, nossoNumero.PadLeft(5, '0'));
-
-            boleto.NossoNumeroDV = Mod11(Sequencial(boleto)).ToString();
-            boleto.NossoNumero = string.Concat(boleto.NossoNumero, Mod11(Sequencial(boleto)));
-
-            boleto.NossoNumeroFormatado = string.Format("{0}/{1}-{2}", boleto.NossoNumero.Substring(0, 2), boleto.NossoNumero.Substring(2, 6), boleto.NossoNumero.Substring(8));
+            if(String.IsNullOrEmpty(boleto.NossoNumero))
+            {
+                var DataDocumento = boleto.DataEmissao.ToString("yy");
+                var nossoNumero = boleto.NossoNumero;
+                boleto.NossoNumero = string.Format("{0}2{1}", DataDocumento, nossoNumero.PadLeft(5, '0'));
+            }
+            //  alguns sistemas fornecem o NossoNumero apenas sem o DV
+            //  cobrindo essas exceções aqui
+            if(boleto.NossoNumero.Length == 8)
+            {
+                boleto.NossoNumeroDV = Mod11(Sequencial(boleto)).ToString();
+                boleto.NossoNumero = string.Concat(boleto.NossoNumero, Mod11(Sequencial(boleto)));
+            }
+            else if (boleto.NossoNumero.Length != 9)
+            {
+                throw new Exception($"Nosso número ({boleto.NossoNumero}) deve conter 9 dígitos.");
+            }
+            //  formatar independente da origem do NossoNumero
+            boleto.NossoNumeroFormatado = string.Format(
+                "{0}/{1}-{2}", 
+                boleto.NossoNumero.Substring(0, 2), 
+                boleto.NossoNumero.Substring(2, 6), 
+                boleto.NossoNumero.Substring(8));
         }
 
         public int Mod11(string seq)


### PR DESCRIPTION
Conforme demonstrei em #191 não era possível fornecer um NossoNumero gerado previamente, na implementação da Carteira 1 do Sicredi. 

Esse PR possibilita tanto fornecer um NossoNumero completo (9 dígitos) quanto faltando apenas o DV (alguns sistemas exportam assim).