### PR TITLE
FormataNossoNumero respeita os testes

### DIFF
--- a/Boleto2.Net/Banco/Carteiras/BancoSicredi/BancoSicrediCarteira1.cs
+++ b/Boleto2.Net/Banco/Carteiras/BancoSicredi/BancoSicrediCarteira1.cs
@@ -27,7 +27,11 @@ namespace Boleto2Net
 
         public void FormataNossoNumero(Boleto boleto)
         {
-            if(String.IsNullOrEmpty(boleto.NossoNumero))
+            var criarNossoNumero = String.IsNullOrEmpty(boleto.NossoNumero)
+                ? true
+                : boleto.NossoNumero.Length < 8;
+
+            if (criarNossoNumero)
             {
                 var DataDocumento = boleto.DataEmissao.ToString("yy");
                 var nossoNumero = boleto.NossoNumero;
@@ -35,7 +39,7 @@ namespace Boleto2Net
             }
             //  alguns sistemas fornecem o NossoNumero apenas sem o DV
             //  cobrindo essas exceções aqui
-            if(boleto.NossoNumero.Length == 8)
+            if (boleto.NossoNumero.Length == 8)
             {
                 boleto.NossoNumeroDV = Mod11(Sequencial(boleto)).ToString();
                 boleto.NossoNumero = string.Concat(boleto.NossoNumero, Mod11(Sequencial(boleto)));


### PR DESCRIPTION
Basicamente modifiquei o método FormataNossoNumero de BancoSicrediCarteira1.cs para que respeitasse os testes que informam o NossoNumero como strings de 1~2 caracteres.

Dessa forma é preservada a possibilidade de informar um NossoNumero completo também.