### PR TITLE
Ajuste no nome do Banco Sicredi

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Nova versão do Boleto.Net
 * Safra (422) - Carteira 1
 * Santander (033) - Carteira 101
 * Sicoob (756) - Carteira 1-01
-* Sicreed (748) - Carteira 1-A
+* Sicredi (748) - Carteira 1-A
 
 ### Carteiras Implementadas (Não foi homologada. Falta teste unitário)
 * Banco do Brasil (001) - Carteira 11 (Variação 019)


### PR DESCRIPTION
O nome do banco estava errado