### PR TITLE
Sicredi - Data de Crédito

### DIFF
--- a/Boleto2.Net/Banco/BancoSicredi.cs
+++ b/Boleto2.Net/Banco/BancoSicredi.cs
@@ -394,7 +394,7 @@ namespace Boleto2Net
                 boleto.ValorPago += boleto.ValorJurosDia;
 
                 // Data do Crédito
-                boleto.DataCredito = Utils.ToDateTime(Utils.ToInt32(registro.Substring(294, 6)).ToString("##-##-##"));
+                boleto.DataCredito = Utils.ToDateTime(Utils.ToInt32(registro.Substring(328, 8)).ToString("####-##-##"));
 
                 // Identificação de Ocorrência - Código Auxiliar
                 boleto.CodigoOcorrenciaAuxiliar = registro.Substring(381, 10);


### PR DESCRIPTION
Ajustado para pegar a data de crédito na posição correta 

Conforme o [manual](https://www.sicredi.com.br/html/para-voce/recebimentos/cobranca/arquivos/manual-cnab-400---2019.pdf#page=54) **página 54 campo Data prevista para lançamento no conta corrente**

Foram feitos vários testes e não vem data na posição que estava pegando antes.

É nessa posição 329 a 336 que vem a data.