### PR TITLE
Ajustado campo multa para duas casas decimais

### DIFF
--- a/Boleto2.Net/Banco/BancoSicredi.cs
+++ b/Boleto2.Net/Banco/BancoSicredi.cs
@@ -135,7 +135,7 @@ namespace Boleto2Net
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0077, 002, 0, 0, '0'));                                                     //077-078
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0079, 004, 0, string.Empty, ' '));                                          //079-082
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0083, 010, 2, boleto.ValorDesconto, '0'));                                  //083-092
-                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0093, 004, 0, boleto.PercentualMulta, '0'));                                //093-096
+                reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediNumericoSemSeparador_, 0093, 004, 2, boleto.PercentualMulta, '0'));                                //093-096
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0097, 012, 0, string.Empty, ' '));                                          //097-108
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0109, 002, 0, "01", ' '));                                                  //109-110 01 - Cadastro de título;
                 reg.CamposEDI.Add(new TCampoRegistroEDI(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0111, 010, 0, boleto.NossoNumero, ' '));                                    //111-120


### PR DESCRIPTION
No campo multa, assim como outros campos numéricos, precisa ser com duas casas decimais conforme testes que fiz.

Exemplo: ao passar 2 para o campo PercentualMulta, no arquivo era gerado 0002 na posição 093-096

O correto é gerar 0200 com dois zeros a direita para o banco considerar 2% de multa.

*Feito testes reais em produção enviado o arquivo para o banco.