### PR TITLE
Alinhado valores auxiliares a direita

### DIFF
--- a/Boleto2.Net/BoletoImpressao/BoletoNet.css
+++ b/Boleto2.Net/BoletoImpressao/BoletoNet.css
@@ -66,6 +66,7 @@ img {
 
 .Ar {
 	text-align: right;
+	padding-right: 3px;
 }
 
 .Al {

--- a/Boleto2.Net/BoletoImpressao/BoletoNetPDF.css
+++ b/Boleto2.Net/BoletoImpressao/BoletoNetPDF.css
@@ -61,6 +61,7 @@ img {
 
 .Ar {
 	text-align: right;
+	padding-right: 3px;
 }
 
 .Al {

--- a/Boleto2.Net/Html.resx
+++ b/Boleto2.Net/Html.resx
@@ -448,15 +448,15 @@
 						&lt;/td&gt;
 						&lt;td class="w186"&gt;
 								&lt;div class="t"&gt;(-) Desconto / Abatimentos&lt;/div&gt;
-								&lt;div class="c BB"&gt;@DESCONTOS&lt;/div&gt;
+								&lt;div class="c BB Ar"&gt;@DESCONTOS&lt;/div&gt;
 								&lt;div class="t"&gt;(-) Outras deduções&lt;/div&gt;
-								&lt;div class="c BB"&gt;@OUTRASDEDUCOES&lt;/div&gt;
+								&lt;div class="c BB Ar"&gt;@OUTRASDEDUCOES&lt;/div&gt;
 								&lt;div class="t"&gt;(+) Mora / Multa&lt;/div&gt;
-								&lt;div class="c BB"&gt;@MORAMULTA&lt;/div&gt;
+								&lt;div class="c BB Ar"&gt;@MORAMULTA&lt;/div&gt;
 								&lt;div class="t"&gt;(+) Outros acréscimos&lt;/div&gt;
-								&lt;div class="c BB"&gt;@OUTROSACRESCIMOS&lt;/div&gt;
+								&lt;div class="c BB Ar"&gt;@OUTROSACRESCIMOS&lt;/div&gt;
 								&lt;div class="t"&gt;(=) Valor cobrado&lt;/div&gt;
-								&lt;div class="c"&gt;@VALORCOBRADO&lt;/div&gt;
+								&lt;div class="c Ar"&gt;@VALORCOBRADO&lt;/div&gt;
 						&lt;/td&gt;
 				&lt;/tr&gt;
 		&lt;/table&gt;</value>


### PR DESCRIPTION
No boleto impresso, alinhado os campos Desconto/Abatimento, Outras deduções, Mora/Multa, Outros acréscimos e Valor cobrado à direita.

