### PR TITLE
Corrigido o código para protesto do Bradesco

### DIFF
--- a/Boleto2.Net/Banco/BancoBradesco.cs
+++ b/Boleto2.Net/Banco/BancoBradesco.cs
@@ -322,6 +322,9 @@ namespace Boleto2Net
                     case TipoCodigoProtesto.ProtestarDiasCorridos:
                         reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 001, 0, 1, '0');
                         break;
+                    case TipoCodigoProtesto.ProtestarDiasUteis:
+                        reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 001, 0, 2, '0');
+                        break;
                     default:
                         reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0221, 001, 0, 0, '0');
                         break;


### PR DESCRIPTION
O código de protesto para dias úteis estava caindo no case default do switch. Incluí um case específico para dias úteis que informa o código 2, conforme consta no manual.