### PR TITLE
Tratamento da instrução de protesto (CodigoProtesto) - Bradesco - remessa CNAB 400

### DIFF
--- a/Boleto2.Net/Banco/BancoBradesco.cs
+++ b/Boleto2.Net/Banco/BancoBradesco.cs
@@ -839,8 +839,24 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0148, 002, 0, AjustaEspecieCnab400(boleto.EspecieDocumento), '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0150, 001, 0, boleto.Aceite, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediDataDDMMAA___________, 0151, 006, 0, boleto.DataEmissao, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0157, 002, 0, boleto.CodigoInstrucao1, '0');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0159, 002, 0, boleto.CodigoInstrucao2, '0');
+
+                //Instruções de protesto
+                string vInstrucao1 = "";
+                string vInstrucao2 = "";
+                switch (boleto.CodigoProtesto)
+                {
+                    case TipoCodigoProtesto.NaoProtestar:
+                        vInstrucao1 = "00";
+                        vInstrucao2 = "0";
+                        break;
+                    case TipoCodigoProtesto.ProtestarDiasCorridos:
+                        vInstrucao1 = "06";
+                        vInstrucao2 = boleto.DiasProtesto.ToString();
+                        break;
+                }
+                reg.Adicionar(TTiposDadoEDI.ediInteiro______________, 0157, 002, 0, vInstrucao1, '0');                                           //157-158
+                reg.Adicionar(TTiposDadoEDI.ediInteiro______________, 0159, 002, 0, vInstrucao2, '0');                                           //159-160
+
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0161, 013, 2, boleto.ValorJurosDia, '0');
 
                 if (boleto.ValorDesconto == 0)


### PR DESCRIPTION
Tratamento da instrução de protesto (CodigoProtesto) para o banco Bradesco na geração de remessa com CNAB 400.
Já existe um tratamento semelhante para o banco Sicredi. No caso do Bradesco, o CodigoProtesto era usado apenas no CNAB 240, para o CNAB 400 era necessário preencher os campos CodigoInstrucao1 e CodigoInstrucao2.