### PR TITLE
Adicionado Data de Geração no ArquivoRetorno para CNAB 400

### DIFF
--- a/Boleto2.Net/Arquivo/ArquivoRetorno.cs
+++ b/Boleto2.Net/Arquivo/ArquivoRetorno.cs
@@ -155,7 +155,7 @@ namespace Boleto2Net
             // Registro HEADER
             if (tipoRegistro == "0")
             {
-                Banco.LerHeaderRetornoCNAB400(registro);
+                Banco.LerHeaderRetornoCNAB400(this, registro);
                 return;
             }
 

--- a/Boleto2.Net/Banco/BancoBanrisul.cs
+++ b/Boleto2.Net/Banco/BancoBanrisul.cs
@@ -434,7 +434,8 @@ namespace Boleto2Net
 
         #region Retorno - CNAB400
 
-        public void LerHeaderRetornoCNAB400(string registro)
+        
+        public void LerHeaderRetornoCNAB400(ArquivoRetorno arquivoRetorno, string registro)
         {
             try
             {
@@ -442,6 +443,9 @@ namespace Boleto2Net
                     throw new Exception("O arquivo não é do tipo \"02RETORNO01COBRANCA\"");
                 if (registro.Substring(76, 11) != "041BANRISUL")
                     throw new Exception("O arquivo não é do tipo \"041BANRISUL\"");
+
+                //095 100 DATA DA GRAVAÇÃO DO ARQUIVO
+                arquivoRetorno.DataGeracao = Utils.ToDateTime(Utils.ToInt32(registro.Substring(94, 6)).ToString("##-##-##"));
             }
             catch (Exception ex)
             {

--- a/Boleto2.Net/Banco/BancoBradesco.cs
+++ b/Boleto2.Net/Banco/BancoBradesco.cs
@@ -666,12 +666,15 @@ namespace Boleto2Net
 
 
         #region CNAB400
-        public void LerHeaderRetornoCNAB400(string registro)
+        public void LerHeaderRetornoCNAB400(ArquivoRetorno arquivoRetorno, string registro)
         {
             try
             {
                 if (registro.Substring(0, 9) != "02RETORNO")
                     throw new Exception("O arquivo não é do tipo \"02RETORNO\"");
+
+                //095 a 100 Data da Gravação do Arquivo 006 DDMMAA
+                arquivoRetorno.DataGeracao = Utils.ToDateTime(Utils.ToInt32(registro.Substring(94, 6)).ToString("##-##-##"));
             }
             catch (Exception ex)
             {

--- a/Boleto2.Net/Banco/BancoBrasil.cs
+++ b/Boleto2.Net/Banco/BancoBrasil.cs
@@ -969,12 +969,15 @@ namespace Boleto2Net
 
         #region Retorno - CNAB400
 
-        public void LerHeaderRetornoCNAB400(string registro)
+        public void LerHeaderRetornoCNAB400(ArquivoRetorno arquivoRetorno, string registro)
         {
             try
             {
                 if (registro.Substring(0, 9) != "02RETORNO")
                     throw new Exception("O arquivo não é do tipo \"02RETORNO\"");
+
+                //14 - 095 a 100 9(006) Data da Gravação: Informe no formado “DDMMAA”
+                arquivoRetorno.DataGeracao = Utils.ToDateTime(Utils.ToInt32(registro.Substring(94, 6)).ToString("##-##-##"));
             }
             catch (Exception ex)
             {

--- a/Boleto2.Net/Banco/BancoCaixa.cs
+++ b/Boleto2.Net/Banco/BancoCaixa.cs
@@ -745,12 +745,16 @@ namespace Boleto2Net
             }
         }
 
-        public void LerHeaderRetornoCNAB400(string registro)
+        public void LerHeaderRetornoCNAB400(ArquivoRetorno arquivoRetorno, string registro)
         {
             try
             {
                 if (registro.Substring(0, 9) != "02RETORNO")
                     throw new Exception("O arquivo não é do tipo \"02RETORNO\"");
+
+                //12.0 Data de Geração Data de Geração do Arquivo 95 100 9(006) NE008
+                arquivoRetorno.DataGeracao = Utils.ToDateTime(Utils.ToInt32(registro.Substring(94, 6)).ToString("##-##-##"));
+
             }
             catch (Exception ex)
             {

--- a/Boleto2.Net/Banco/BancoItau.cs
+++ b/Boleto2.Net/Banco/BancoItau.cs
@@ -142,12 +142,16 @@ namespace Boleto2Net
             throw new NotImplementedException();
         }
 
-        public void LerHeaderRetornoCNAB400(string registro)
+        public void LerHeaderRetornoCNAB400(ArquivoRetorno arquivoRetorno, string registro)
         {
             try
             {
                 if (registro.Substring(0, 9) != "02RETORNO")
                     throw new Exception("O arquivo não é do tipo \"02RETORNO\"");
+
+                //DATA DE GERAÇÃO DATA DE GERAÇÃO DO ARQUIVO 095 100
+                arquivoRetorno.DataGeracao = Utils.ToDateTime(Utils.ToInt32(registro.Substring(94, 6)).ToString("##-##-##"));
+
             }
             catch (Exception ex)
             {

--- a/Boleto2.Net/Banco/BancoSafra.cs
+++ b/Boleto2.Net/Banco/BancoSafra.cs
@@ -136,12 +136,15 @@ namespace Boleto2Net
             throw new NotImplementedException();
         }
 
-        public void LerHeaderRetornoCNAB400(string registro)
+        public void LerHeaderRetornoCNAB400(ArquivoRetorno arquivoRetorno, string registro)
         {
             try
             {
                 if (registro.Substring(0, 9) != "02RETORNO")
                     throw new Exception("O arquivo não é do tipo \"02RETORNO\"");
+
+                arquivoRetorno.DataGeracao = Utils.ToDateTime(Utils.ToInt32(registro.Substring(94, 6)).ToString("##-##-##"));
+
             }
             catch (Exception ex)
             {

--- a/Boleto2.Net/Banco/BancoSantander.cs
+++ b/Boleto2.Net/Banco/BancoSantander.cs
@@ -290,7 +290,7 @@ namespace Boleto2Net
             }
         }
 
-        public void LerHeaderRetornoCNAB400(string registro)
+        public void LerHeaderRetornoCNAB400(ArquivoRetorno arquivoRetorno, string registro)
         {
             throw new NotImplementedException();
         }

--- a/Boleto2.Net/Banco/BancoSicoob.cs
+++ b/Boleto2.Net/Banco/BancoSicoob.cs
@@ -826,7 +826,7 @@ namespace Boleto2Net
         #endregion
 
         #region Retorno - CNAB400
-        public void LerHeaderRetornoCNAB400(string registro)
+        public void LerHeaderRetornoCNAB400(ArquivoRetorno arquivoRetorno, string registro)
         {
             try
             {
@@ -834,6 +834,10 @@ namespace Boleto2Net
                 {
                     throw new Exception("O arquivo não é do tipo \"02RETORNO\"");
                 }
+
+                //095 a 100 Data de Gravação do Arquivo 006 DDMMAA
+                arquivoRetorno.DataGeracao = Utils.ToDateTime(Utils.ToInt32(registro.Substring(94, 6)).ToString("##-##-##"));
+
             }
             catch (Exception ex)
             {

--- a/Boleto2.Net/Banco/BancoSicredi.cs
+++ b/Boleto2.Net/Banco/BancoSicredi.cs
@@ -504,12 +504,20 @@ namespace Boleto2Net
             throw new NotImplementedException();
         }
 
-        public void LerHeaderRetornoCNAB400(string registro)
+        public void LerHeaderRetornoCNAB400(ArquivoRetorno arquivoRetorno, string registro)
         {
             try
             {
                 if (registro.Substring(0, 9) != "02RETORNO")
                     throw new Exception("O arquivo não é do tipo \"02RETORNO\"");
+
+                var dataStr = Utils.ToInt32(registro.Substring(94, 8)).ToString("####-##-##").Split('-');
+                var ano = Utils.ToInt32(dataStr[0]);
+                var mes = Utils.ToInt32(dataStr[1]);
+                var dia = Utils.ToInt32(dataStr[2]);
+
+                //095 a 102 008 Data de gravação do arquivo AAAAMMDD
+                arquivoRetorno.DataGeracao = new DateTime(ano, mes, dia);
             }
             catch (Exception ex)
             {

--- a/Boleto2.Net/Banco/IBanco.cs
+++ b/Boleto2.Net/Banco/IBanco.cs
@@ -49,7 +49,7 @@ namespace Boleto2Net
         void LerHeaderRetornoCNAB240(ArquivoRetorno arquivoRetorno, string registro);
         void LerDetalheRetornoCNAB240SegmentoT(ref Boleto boleto, string registro);
         void LerDetalheRetornoCNAB240SegmentoU(ref Boleto boleto, string registro);
-        void LerHeaderRetornoCNAB400(string registro);
+        void LerHeaderRetornoCNAB400(ArquivoRetorno arquivoRetorno, string registro);
         void LerDetalheRetornoCNAB400Segmento1(ref Boleto boleto, string registro);
         void LerDetalheRetornoCNAB400Segmento7(ref Boleto boleto, string registro);
         void LerTrailerRetornoCNAB400(string registro);


### PR DESCRIPTION
No CNAB 240, ao gerar o header do retorno, ele atribui a DataGeracao do arquivo retorno pelo header. O CNAB não fazia isso. Eu adicionei essa funcionalidade.