### PR TITLE
Correção impressão modo Carnê para que caibam 3 boletos em 1 folha A4

### DIFF
--- a/Boleto2.Net/BoletoImpressao/BoletoNet.css
+++ b/Boleto2.Net/BoletoImpressao/BoletoNet.css
@@ -162,6 +162,14 @@ img {
 	height: 1px;
 }
 
+.h10 {
+	height: 10px;
+}
+
+.h10 td {
+	vertical-align: top;
+}
+
 .h13 {
 	height: 13px;
 }
@@ -385,7 +393,7 @@ img {
 
 .ebc {
 	width: 4px;
-	height: 440px;
+	height: 420px;
 	border-right: dotted 1px #000000;
 	margin-right: 4px;
 }

--- a/Boleto2.Net/Html.Designer.cs
+++ b/Boleto2.Net/Html.Designer.cs
@@ -19,7 +19,7 @@ namespace Boleto2Net {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Html {
@@ -417,17 +417,9 @@ namespace Boleto2Net {
         
         /// <summary>
         ///   Looks up a localized string similar to &lt;table class=&quot;ctN w666&quot;&gt;
-        ///				&lt;tr class=&quot;h13&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
+        ///				&lt;tr class=&quot;h10&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
         ///				&lt;tr&gt;&lt;td class=&quot;Ar&quot;&gt;Corte na linha pontilhada&lt;/td&gt;&lt;/tr&gt;
         ///				&lt;tr&gt;&lt;td class=&quot;cut&quot; /&gt;&lt;/tr&gt;
-        ///		&lt;/table&gt;
-        ///		&lt;table class=&quot;ctN w666&quot;&gt;
-        ///				&lt;tr class=&quot;h13&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
-        ///				&lt;tr class=&quot;h13&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
-        ///				&lt;tr class=&quot;h13&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
-        ///				&lt;tr class=&quot;h13&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
-        ///				&lt;tr class=&quot;h13&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
-        ///				&lt;tr class=&quot;h13&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
         ///		&lt;/table&gt;.
         /// </summary>
         internal static string ReciboCedenteParte12 {
@@ -528,11 +520,11 @@ namespace Boleto2Net {
         ///						&lt;/td&gt;
         ///						&lt;td class=&quot;w186&quot;&gt;
         ///								&lt;div class=&quot;t&quot;&gt;(-) Desconto / Abatimentos&lt;/div&gt;
-        ///								&lt;div class=&quot;c BB&quot;&gt;@DESCONTOS&lt;/div&gt;
+        ///								&lt;div class=&quot;c BB Ar&quot;&gt;@DESCONTOS&lt;/div&gt;
         ///								&lt;div class=&quot;t&quot;&gt;(-) Outras deduções&lt;/div&gt;
-        ///								&lt;div class=&quot;c BB&quot;&gt;@OUTRASDEDUCOES&lt;/div&gt;
+        ///								&lt;div class=&quot;c BB Ar&quot;&gt;@OUTRASDEDUCOES&lt;/div&gt;
         ///								&lt;div class=&quot;t&quot;&gt;(+) Mora / Multa&lt;/div&gt;
-        ///								&lt;div clas [rest of string was truncated]&quot;;.
+        ///								&lt;di [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboCedenteParte6 {
             get {

--- a/Boleto2.Net/Html.resx
+++ b/Boleto2.Net/Html.resx
@@ -360,17 +360,9 @@
   </data>
   <data name="ReciboCedenteParte12" xml:space="preserve">
     <value>&lt;table class="ctN w666"&gt;
-				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
+				&lt;tr class="h10"&gt;&lt;td /&gt;&lt;/tr&gt;
 				&lt;tr&gt;&lt;td class="Ar"&gt;Corte na linha pontilhada&lt;/td&gt;&lt;/tr&gt;
 				&lt;tr&gt;&lt;td class="cut" /&gt;&lt;/tr&gt;
-		&lt;/table&gt;
-		&lt;table class="ctN w666"&gt;
-				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
-				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
-				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
-				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
-				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
-				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
 		&lt;/table&gt;</value>
   </data>
   <data name="ReciboCedenteParte2" xml:space="preserve">


### PR DESCRIPTION
Foi removido os espaços em branco no final de cada boleto (Arquivo html.resx/ReciboCedenteParte12) para que caiba 3 em uma unica folha A4 quando utilizando a impressão em modo Carnê. Criei um H10 no CSS para reduzir o tamanho desses espaçamentos, pois antes só tinha o H13. Não mexi em arquivos .cs que alteram a funcionalidade do boleto, apenas nessa parte da impressão.