### PR TITLE
Pequena correção na impressão de boleto em modo Carnê

### DIFF
--- a/Boleto2.Net/BoletoImpressao/BoletoNet.css
+++ b/Boleto2.Net/BoletoImpressao/BoletoNet.css
@@ -162,20 +162,28 @@ img {
 	height: 1px;
 }
 
-.h10 {
-	height: 10px;
-}
-
-.h10 td {
-	vertical-align: top;
-}
-
 .h13 {
 	height: 13px;
 }
 
 .h12 {
 	height: 12px;
+}
+
+.h5 {
+	height: 5px;
+}
+
+	.h5 td {
+		vertical-align: top;
+	}
+
+.h10 {
+	height: 10px;
+}
+
+.h10 td {
+	vertical-align: top;
 }
 
 .h13 td {

--- a/Boleto2.Net/Html.Designer.cs
+++ b/Boleto2.Net/Html.Designer.cs
@@ -124,7 +124,8 @@ namespace Boleto2Net {
         ///														&lt;/td&gt;
         ///												&lt;/tr&gt;
         ///												&lt;tr class=&quot;cp h12 At rBb&quot;&gt;
-        ///														&lt;td&gt;        /// [rest of string was truncated]&quot;;.
+        ///														&lt;td&gt;
+        ///																@ [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Carne {
             get {
@@ -262,7 +263,7 @@ namespace Boleto2Net {
         ///												&lt;td class=&quot;w104&quot;&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Ausente&lt;/td&gt;
         ///												&lt;td&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Não existe n. indicado&lt;/td&gt;
         ///												&lt;td&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Recusado&lt;/td&gt;
-        ///												&lt;td class=&quot;w104&quot;&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp; [rest of string was truncated]&quot;;.
+        ///												&lt;td class=&quot;w104&quot;&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Não Procurad [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ComprovanteEntrega7 {
             get {
@@ -290,7 +291,9 @@ namespace Boleto2Net {
         ///							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
         ///							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
         ///							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
-        ///							 &lt;td&gt;&amp;nbsp;&lt;/ [rest of string was truncated]&quot;;.
+        ///							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
+        ///						&lt;/tr&gt;
+        ///			 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ComprovanteEntrega71 {
             get {
@@ -393,7 +396,7 @@ namespace Boleto2Net {
         ///						&lt;td class=&quot;pL6  w409&quot;&gt;Sacador / Avalista &lt;b class=&quot;cpN&quot;&gt;@AVALISTA&lt;/b&gt;&lt;/td&gt;
         ///						&lt;td class=&quot;w250 Ar&quot;&gt;Autenticação mecânica - &lt;b class=&quot;cpN&quot;&gt;Ficha de Compensação&lt;/b&gt;&lt;/td&gt;
         ///				&lt;/tr&gt;
-        ///				&lt;tr class=&quot;h13&quot;&gt;&lt;td colspan=&quot;3&quot; /&gt;&lt;/tr&gt;
+        ///				&lt;tr class=&quot;h5&quot;&gt;&lt;td colspan=&quot;3&quot; /&gt;&lt;/tr&gt;
         ///		&lt;/table&gt;.
         /// </summary>
         internal static string ReciboCedenteParte10 {
@@ -417,7 +420,7 @@ namespace Boleto2Net {
         
         /// <summary>
         ///   Looks up a localized string similar to &lt;table class=&quot;ctN w666&quot;&gt;
-        ///				&lt;tr class=&quot;h10&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
+        ///				&lt;tr class=&quot;h5&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
         ///				&lt;tr&gt;&lt;td class=&quot;Ar&quot;&gt;Corte na linha pontilhada&lt;/td&gt;&lt;/tr&gt;
         ///				&lt;tr&gt;&lt;td class=&quot;cut&quot; /&gt;&lt;/tr&gt;
         ///		&lt;/table&gt;.
@@ -479,7 +482,8 @@ namespace Boleto2Net {
         ///						&lt;td&gt;@NUMERODOCUMENTO&lt;/td&gt;
         ///						&lt;td&gt;@ESPECIEDOCUMENTO&lt;/td&gt;
         ///						&lt;td&gt;@ACEITE&lt;/td&gt;
-        ///						&lt;td&gt;@DATAPROCESSAMENTO&lt;/t [rest of string was truncated]&quot;;.
+        ///						&lt;td&gt;@DATAPROCESSAMENTO&lt;/td&gt;
+        ///						&lt;td c [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboCedenteParte4 {
             get {
@@ -503,7 +507,8 @@ namespace Boleto2Net {
         ///						&lt;td&gt;&amp;nbsp;&lt;/td&gt;
         ///						&lt;td class=&quot;Al&quot;&gt;@CARTEIRA&lt;/td&gt;
         ///						&lt;td class=&quot;Al&quot;&gt;@ESPECIE&lt;/td&gt;
-        ///						&lt;td&gt;@QUANTIDADE&lt;/ [rest of string was truncated]&quot;;.
+        ///						&lt;td&gt;@QUANTIDADE&lt;/td&gt;
+        ///						&lt;td&gt;@ [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboCedenteParte5 {
             get {
@@ -524,7 +529,7 @@ namespace Boleto2Net {
         ///								&lt;div class=&quot;t&quot;&gt;(-) Outras deduções&lt;/div&gt;
         ///								&lt;div class=&quot;c BB Ar&quot;&gt;@OUTRASDEDUCOES&lt;/div&gt;
         ///								&lt;div class=&quot;t&quot;&gt;(+) Mora / Multa&lt;/div&gt;
-        ///								&lt;di [rest of string was truncated]&quot;;.
+        ///								&lt;div class=&quot;c B [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboCedenteParte6 {
             get {
@@ -590,7 +595,8 @@ namespace Boleto2Net {
         ///				&lt;tr class=&quot;ct h13&quot;&gt;
         ///						&lt;td&gt;Local de pagamento&lt;/td&gt;
         ///						&lt;td&gt;&lt;/td&gt;
-        ///				&lt;/tr&gt;			 [rest of string was truncated]&quot;;.
+        ///				&lt;/tr&gt;						
+        ///				&lt;tr cl [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboCedenteRelatorioValores {
             get {
@@ -709,7 +715,8 @@ namespace Boleto2Net {
         ///						&lt;td&gt;@MORAMULTA&lt;/td&gt;
         ///						&lt;td&gt;@OUTROSACRESCIMOS&lt;/td&gt;
         ///						&lt;td class=&quot;Ar&quot;&gt;&amp;nbsp;@VALORCOBRADO&lt;/td&gt;
-        ///				&lt;/ [rest of string was truncated]&quot;;.
+        ///				&lt;/tr&gt;
+        ///		&lt;/table&gt;.
         /// </summary>
         internal static string ReciboSacadoParte5 {
             get {

--- a/Boleto2.Net/Html.resx
+++ b/Boleto2.Net/Html.resx
@@ -348,7 +348,7 @@
 						&lt;td class="pL6  w409"&gt;Sacador / Avalista &lt;b class="cpN"&gt;@AVALISTA&lt;/b&gt;&lt;/td&gt;
 						&lt;td class="w250 Ar"&gt;Autenticação mecânica - &lt;b class="cpN"&gt;Ficha de Compensação&lt;/b&gt;&lt;/td&gt;
 				&lt;/tr&gt;
-				&lt;tr class="h13"&gt;&lt;td colspan="3" /&gt;&lt;/tr&gt;
+				&lt;tr class="h5"&gt;&lt;td colspan="3" /&gt;&lt;/tr&gt;
 		&lt;/table&gt;</value>
   </data>
   <data name="ReciboCedenteParte11" xml:space="preserve">
@@ -360,7 +360,7 @@
   </data>
   <data name="ReciboCedenteParte12" xml:space="preserve">
     <value>&lt;table class="ctN w666"&gt;
-				&lt;tr class="h10"&gt;&lt;td /&gt;&lt;/tr&gt;
+				&lt;tr class="h5"&gt;&lt;td /&gt;&lt;/tr&gt;
 				&lt;tr&gt;&lt;td class="Ar"&gt;Corte na linha pontilhada&lt;/td&gt;&lt;/tr&gt;
 				&lt;tr&gt;&lt;td class="cut" /&gt;&lt;/tr&gt;
 		&lt;/table&gt;</value>


### PR DESCRIPTION
No windows 10 funcionava corretamente a impressão A4, ja no windows 7 as fontes usadas na impressão causavam quebra de linha, fazendo com que o código de barras desse quebra de página.