### PR TITLE
Correção do campo instruções do recibo do pagador

### DIFF
--- a/Boleto2.Net/BoletoImpressao/BoletoNet.css
+++ b/Boleto2.Net/BoletoImpressao/BoletoNet.css
@@ -82,9 +82,9 @@ img {
 }
 
 .ct td, .cp td {
-    padding-left: 3px;
+    padding-left: 3.5px;
     border-left: solid 1px #000;
-    padding-right: 3px;
+    padding-right: 3.5px;
     border-right: solid 1px #000;
 }
 
@@ -108,6 +108,18 @@ img {
 
 .pL10 {
 	padding-left: 10px;
+}
+
+.bleft {
+	border-left: solid 1px #000;
+}
+
+.bright {
+	border-right: solid 1px #000;
+}
+
+.bbottom {
+	border-bottom: solid 1px #000;
 }
 
 .imgLogo {
@@ -226,6 +238,14 @@ img {
 	width: 65px;
 }
 
+.w74 {
+	width: 74px;
+}
+
+.w76 {
+	width: 76px;
+}
+
 .w72 {
 	width: 72px;
 }
@@ -320,6 +340,14 @@ img {
 
 .w450 {
     width: 409px;
+}
+
+.w465 {
+	width: 465px;
+}
+
+.w455 {
+	width: 455px;
 }
 
 .w472 {

--- a/Boleto2.Net/BoletoImpressao/BoletoNetPDF.css
+++ b/Boleto2.Net/BoletoImpressao/BoletoNetPDF.css
@@ -77,9 +77,9 @@ img {
 }
 
 .ct td, .cp td {
-    padding-left: 3px;
+    padding-left: 3.5px;
     border-left: solid 1px #000;
-    padding-right: 3px;
+    padding-right: 3.5px;
     border-right: solid 1px #000;
 }
 
@@ -103,6 +103,18 @@ img {
 
 .pL10 {
 	padding-left: 10px;
+}
+
+.bleft {
+	border-left: solid 1px #000;
+}
+
+.bright {
+	border-right: solid 1px #000;
+}
+
+.bbottom {
+	border-bottom: solid 1px #000;
 }
 
 .imgLogo {
@@ -205,6 +217,14 @@ img {
 	width: 65px;
 }
 
+.w74 {
+	width: 74px;
+}
+
+.w76 {
+	width: 76px;
+}
+
 .w72 {
 	width: 72px;
 }
@@ -295,6 +315,14 @@ img {
 
 .w409 {
 	width: 409px;
+}
+
+.w465 {
+	width: 465px;
+}
+
+.w455 {
+	width: 455px;
 }
 
 .w472 {

--- a/Boleto2.Net/Html.Designer.cs
+++ b/Boleto2.Net/Html.Designer.cs
@@ -124,8 +124,7 @@ namespace Boleto2Net {
         ///														&lt;/td&gt;
         ///												&lt;/tr&gt;
         ///												&lt;tr class=&quot;cp h12 At rBb&quot;&gt;
-        ///														&lt;td&gt;
-        ///																@ [rest of string was truncated]&quot;;.
+        ///														&lt;td&gt;        /// [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Carne {
             get {
@@ -263,7 +262,7 @@ namespace Boleto2Net {
         ///												&lt;td class=&quot;w104&quot;&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Ausente&lt;/td&gt;
         ///												&lt;td&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Não existe n. indicado&lt;/td&gt;
         ///												&lt;td&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Recusado&lt;/td&gt;
-        ///												&lt;td class=&quot;w104&quot;&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp;Não Procurad [rest of string was truncated]&quot;;.
+        ///												&lt;td class=&quot;w104&quot;&gt;(&amp;nbsp;&amp;nbsp;)&amp;nbsp; [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ComprovanteEntrega7 {
             get {
@@ -291,9 +290,7 @@ namespace Boleto2Net {
         ///							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
         ///							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
         ///							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
-        ///							 &lt;td&gt;&amp;nbsp;&lt;/td&gt;
-        ///						&lt;/tr&gt;
-        ///			 [rest of string was truncated]&quot;;.
+        ///							 &lt;td&gt;&amp;nbsp;&lt;/ [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ComprovanteEntrega71 {
             get {
@@ -482,8 +479,7 @@ namespace Boleto2Net {
         ///						&lt;td&gt;@NUMERODOCUMENTO&lt;/td&gt;
         ///						&lt;td&gt;@ESPECIEDOCUMENTO&lt;/td&gt;
         ///						&lt;td&gt;@ACEITE&lt;/td&gt;
-        ///						&lt;td&gt;@DATAPROCESSAMENTO&lt;/td&gt;
-        ///						&lt;td c [rest of string was truncated]&quot;;.
+        ///						&lt;td&gt;@DATAPROCESSAMENTO&lt;/t [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboCedenteParte4 {
             get {
@@ -507,8 +503,7 @@ namespace Boleto2Net {
         ///						&lt;td&gt;&amp;nbsp;&lt;/td&gt;
         ///						&lt;td class=&quot;Al&quot;&gt;@CARTEIRA&lt;/td&gt;
         ///						&lt;td class=&quot;Al&quot;&gt;@ESPECIE&lt;/td&gt;
-        ///						&lt;td&gt;@QUANTIDADE&lt;/td&gt;
-        ///						&lt;td&gt;@ [rest of string was truncated]&quot;;.
+        ///						&lt;td&gt;@QUANTIDADE&lt;/ [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboCedenteParte5 {
             get {
@@ -529,7 +524,7 @@ namespace Boleto2Net {
         ///								&lt;div class=&quot;t&quot;&gt;(-) Outras deduções&lt;/div&gt;
         ///								&lt;div class=&quot;c BB Ar&quot;&gt;@OUTRASDEDUCOES&lt;/div&gt;
         ///								&lt;div class=&quot;t&quot;&gt;(+) Mora / Multa&lt;/div&gt;
-        ///								&lt;div class=&quot;c B [rest of string was truncated]&quot;;.
+        ///								&lt;di [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboCedenteParte6 {
             get {
@@ -595,8 +590,7 @@ namespace Boleto2Net {
         ///				&lt;tr class=&quot;ct h13&quot;&gt;
         ///						&lt;td&gt;Local de pagamento&lt;/td&gt;
         ///						&lt;td&gt;&lt;/td&gt;
-        ///				&lt;/tr&gt;						
-        ///				&lt;tr cl [rest of string was truncated]&quot;;.
+        ///				&lt;/tr&gt;			 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboCedenteRelatorioValores {
             get {
@@ -715,12 +709,27 @@ namespace Boleto2Net {
         ///						&lt;td&gt;@MORAMULTA&lt;/td&gt;
         ///						&lt;td&gt;@OUTROSACRESCIMOS&lt;/td&gt;
         ///						&lt;td class=&quot;Ar&quot;&gt;&amp;nbsp;@VALORCOBRADO&lt;/td&gt;
-        ///				&lt;/tr&gt;
-        ///		&lt;/table&gt;.
+        ///				&lt;/ [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ReciboSacadoParte5 {
             get {
                 return ResourceManager.GetString("ReciboSacadoParte5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;table class=&quot;w666&quot;&gt;
+        ///				&lt;tr class=&quot;ctN h13&quot;&gt;
+        ///						&lt;td class=&quot;pL6 bleft bright&quot;&gt;Instruções&lt;/td&gt;
+        ///				&lt;/tr&gt;
+        ///				&lt;tr class=&quot;cpN h12&quot;&gt;
+        ///						&lt;td class=&quot;pL6 bleft bright bbottom&quot;&gt;@MENSAGEMFIXASACADO@INSTRUCOES&lt;/td&gt;
+        ///				&lt;/tr&gt;
+        ///		&lt;/table&gt;.
+        /// </summary>
+        internal static string ReciboSacadoParte6 {
+            get {
+                return ResourceManager.GetString("ReciboSacadoParte6", resourceCulture);
             }
         }
         
@@ -737,24 +746,6 @@ namespace Boleto2Net {
         ///				&lt;/tr&gt;
         ///		&lt;/table&gt;.
         /// </summary>
-        internal static string ReciboSacadoParte6 {
-            get {
-                return ResourceManager.GetString("ReciboSacadoParte6", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to &lt;table class=&quot;w666&quot;&gt;
-        ///				&lt;tr class=&quot;ctN h13&quot;&gt;
-        ///						&lt;td class=&quot;pL6&quot;&gt;Instruções&lt;/td&gt;
-        ///						&lt;td class=&quot;w180 Ar&quot;&gt;Autenticação mecânica&lt;/td&gt;
-        ///				&lt;/tr&gt;
-        ///				&lt;tr class=&quot;cpN h12&quot;&gt;
-        ///						&lt;td class=&quot;pL6&quot;&gt;@MENSAGEMFIXASACADO@INSTRUCOES&lt;/td&gt;
-        ///						&lt;td class=&quot;pL6 Ar&quot;&gt;@AUTENTICACAOMECANICA&lt;/td&gt;
-        ///				&lt;/tr&gt;
-        ///		&lt;/table&gt;.
-        /// </summary>
         internal static string ReciboSacadoParte7 {
             get {
                 return ResourceManager.GetString("ReciboSacadoParte7", resourceCulture);
@@ -763,7 +754,7 @@ namespace Boleto2Net {
         
         /// <summary>
         ///   Looks up a localized string similar to &lt;table class=&quot;ctN w666&quot;&gt;
-        ///				&lt;tr class=&quot;h13&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
+        ///				&lt;tr class=&quot;h13&quot;&gt;Autenticação mecânica&lt;td /&gt;&lt;/tr&gt;
         ///				&lt;tr class=&quot;h13&quot;&gt;&lt;td /&gt;&lt;/tr&gt;
         ///				&lt;tr&gt;&lt;td class=&quot;Ar&quot;&gt;Corte na linha pontilhada&lt;/td&gt;&lt;/tr&gt;
         ///				&lt;tr&gt;&lt;td class=&quot;cut&quot; /&gt;&lt;/tr&gt;

--- a/Boleto2.Net/Html.resx
+++ b/Boleto2.Net/Html.resx
@@ -283,7 +283,7 @@
 						&lt;td&gt;&lt;/td&gt;						
 				&lt;/tr&gt;						
 				&lt;tr class="ct h13"&gt;
-						&lt;td class="w472"&gt;Beneficiário&lt;/td&gt;
+						&lt;td class="w455"&gt;Beneficiário&lt;/td&gt;
 						&lt;td class="w180"&gt;Agência / Código Beneficiário&lt;/td&gt;
 				&lt;/tr&gt;
 				&lt;tr class="cp h12 rBb"&gt;
@@ -380,7 +380,7 @@
   <data name="ReciboCedenteParte3" xml:space="preserve">
     <value>&lt;table class="w666"&gt;
 				&lt;tr class="ct h13"&gt;
-						&lt;td class="w472"&gt;Beneficiário&lt;/td&gt;
+						&lt;td class="w465"&gt;Beneficiário&lt;/td&gt;
 						&lt;td class="w180"&gt;Agência / Código Beneficiário&lt;/td&gt;
 				&lt;/tr&gt;
 				&lt;tr class="cp h12 rBb"&gt;
@@ -396,7 +396,7 @@
 						&lt;td class="w163"&gt;N&lt;u&gt;o&lt;/u&gt; documento&lt;/td&gt;
 						&lt;td class="w62"&gt;Espécie doc.&lt;/td&gt;
 						&lt;td class="w34"&gt;Aceite&lt;/td&gt;
-						&lt;td class="w72"&gt;Data processamento&lt;/td&gt;
+						&lt;td class="w74"&gt;Data processamento&lt;/td&gt;
 						&lt;td class="w180"&gt;Carteira / Nosso número&lt;/td&gt;
 				&lt;/tr&gt;
 				&lt;tr class="cp h12 rBb"&gt;
@@ -417,7 +417,7 @@
 						&lt;td class="w83"&gt;Carteira&lt;/td&gt;
 						&lt;td class="w53"&gt;Espécie&lt;/td&gt;
 						&lt;td class="w123"&gt;Quantidade&lt;/td&gt;
-						&lt;td class="w72"&gt;(x) Valor&lt;/td&gt;
+						&lt;td class="w74"&gt;(x) Valor&lt;/td&gt;
 						&lt;td class="w180 bgcGray"&gt;(=) Valor documento&lt;/td&gt;
 				&lt;/tr&gt;
 				&lt;tr class="cp h12 rBb"&gt;
@@ -524,7 +524,7 @@
 						&lt;td class="w192"&gt;Número do documento&lt;/td&gt;
 						&lt;td class="w132"&gt;CPF/CNPJ&lt;/td&gt;
 						&lt;td class="w134"&gt;Vencimento&lt;/td&gt;
-						&lt;td class="w180"&gt;Valor documento&lt;/td&gt;
+						&lt;td class="w182"&gt;Valor documento&lt;/td&gt;
 				&lt;/tr&gt;
 				&lt;tr class="cp h12 rBb"&gt;
 						&lt;td&gt;@NUMERODOCUMENTO&lt;/td&gt;
@@ -554,6 +554,16 @@
   </data>
   <data name="ReciboSacadoParte6" xml:space="preserve">
     <value>&lt;table class="w666"&gt;
+				&lt;tr class="ctN h13"&gt;
+						&lt;td class="pL6 bleft bright"&gt;Instruções&lt;/td&gt;
+				&lt;/tr&gt;
+				&lt;tr class="cpN h12"&gt;
+						&lt;td class="pL6 bleft bright bbottom"&gt;@MENSAGEMFIXASACADO@INSTRUCOES&lt;/td&gt;
+				&lt;/tr&gt;
+		&lt;/table&gt;</value>
+  </data>
+  <data name="ReciboSacadoParte7" xml:space="preserve">
+    <value>&lt;table class="w666"&gt;
 				&lt;tr class="ct h13"&gt;
 						&lt;td class="w659"&gt;Pagador&lt;/td&gt;
 				&lt;/tr&gt;
@@ -565,27 +575,17 @@
 				&lt;/tr&gt;
 		&lt;/table&gt;</value>
   </data>
-  <data name="ReciboSacadoParte7" xml:space="preserve">
-    <value>&lt;table class="w666"&gt;
-				&lt;tr class="ctN h13"&gt;
-						&lt;td class="pL6"&gt;Instruções&lt;/td&gt;
-						&lt;td class="w180 Ar"&gt;Autenticação mecânica&lt;/td&gt;
-				&lt;/tr&gt;
-				&lt;tr class="cpN h12"&gt;
-						&lt;td class="pL6"&gt;@MENSAGEMFIXASACADO@INSTRUCOES&lt;/td&gt;
-						&lt;td class="pL6 Ar"&gt;@AUTENTICACAOMECANICA&lt;/td&gt;
-				&lt;/tr&gt;
-		&lt;/table&gt;</value>
-  </data>
   <data name="ReciboSacadoParte8" xml:space="preserve">
-    <value>&lt;table class="ctN w666"&gt;
-				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
+    <value>
+	&lt;table class="ctN w666"&gt;
+				&lt;tr&gt;&lt;td class="Ar"&gt;Autenticação mecânica&lt;/td&gt;&lt;/tr&gt;
 				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
 				&lt;tr&gt;&lt;td class="Ar"&gt;Corte na linha pontilhada&lt;/td&gt;&lt;/tr&gt;
 				&lt;tr&gt;&lt;td class="cut" /&gt;&lt;/tr&gt;
 				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
 				&lt;tr class="h13"&gt;&lt;td /&gt;&lt;/tr&gt;
-		&lt;/table&gt;</value>
+		&lt;/table&gt;
+		</value>
   </data>
   <data name="ComprovanteEntrega71" xml:space="preserve">
     <value>&lt;table class="w666"&gt;


### PR DESCRIPTION
Quando o boleto é gerado o campo de instrução estava sem configuração de estilo

![image](https://user-images.githubusercontent.com/19397427/91642025-7315e080-e9fe-11ea-8ac4-c66b25b22b61.png)

Fiz a correção do campo usando o manual banco Safra e banco Bradesco, seguindo as orientações do documento.

![image](https://user-images.githubusercontent.com/19397427/91642070-bf612080-e9fe-11ea-838f-8d573fda1801.png)

E também fiz algumas correções no layout do boleto para alinhar os campos 

![image](https://user-images.githubusercontent.com/19397427/91642093-e7e91a80-e9fe-11ea-89d2-9c7f4a599ba9.png)

Segue o layout completo com as correções:
![image](https://user-images.githubusercontent.com/19397427/91642158-69d94380-e9ff-11ea-96b1-8950e92e426a.png)

