### PR TITLE
Correções para leitura do arquivo de retorno

### DIFF
--- a/Boleto2.Net/Arquivo/ArquivoRetorno.cs
+++ b/Boleto2.Net/Arquivo/ArquivoRetorno.cs
@@ -83,11 +83,11 @@ namespace Boleto2Net
                     //atribui o tipo de acordo com o conteúdo do arquivo
                     TipoArquivo = registro.Length == 240 ? TipoArquivo.CNAB240 : TipoArquivo.CNAB400;
 
-                    if (TipoArquivo == TipoArquivo.CNAB400 && Banco.IdsRetornoCnab400RegistroDetalhe.Count == 0)
-                        throw new Exception("Banco " + Banco.Codigo.ToString() + " não implementou os Ids do Registro Retorno do CNAB400.");
-
                     //instacia o banco de acordo com o codigo/id do banco presente no arquivo de retorno
                     Banco = Boleto2Net.Banco.Instancia(Utils.ToInt32(registro.Substring(TipoArquivo == TipoArquivo.CNAB240 ? 0 : 76, 3)));
+
+                    if (TipoArquivo == TipoArquivo.CNAB400 && Banco.IdsRetornoCnab400RegistroDetalhe.Count == 0)
+                        throw new Exception("Banco " + Banco.Codigo.ToString() + " não implementou os Ids do Registro Retorno do CNAB400.");
 
                     //define a posicao do reader para o início
                     arquivoRetorno.DiscardBufferedData();

--- a/Boleto2.Net/Boleto/Boleto.cs
+++ b/Boleto2.Net/Boleto/Boleto.cs
@@ -21,7 +21,7 @@ namespace Boleto2Net
         {
             Banco = banco;
             //se o arquivo de retorno for criado par multiplas carteiras, ignora a carteira (para compatibilidade)
-            if (!ignorarCarteira)
+            if ((!ignorarCarteira) && (banco.Cedente != null))
             {
                 Carteira = banco.Cedente.ContaBancaria.CarteiraPadrao;
                 VariacaoCarteira = banco.Cedente.ContaBancaria.VariacaoCarteiraPadrao;
@@ -60,8 +60,8 @@ namespace Boleto2Net
         public decimal ValorTitulo { get; set; }
 
         public bool ImprimirValoresAuxiliares { get; set; } = false;
-        public decimal ValorPago { get; set; } // ValorPago deve ser preenchido com o valor que o sacado pagou. Se n„o existir essa informaÁ„o no arquivo retorno, deixar zerada.
-        public decimal ValorPagoCredito { get; set; } // ValorPagoCredito deve ser preenchido com o valor que ser· creditado na conta corrente. Se n„o existir essa informaÁ„o no arquivo retorno, deixar zerada.
+        public decimal ValorPago { get; set; } // ValorPago deve ser preenchido com o valor que o sacado pagou. Se n√£o existir essa informa√ß√£o no arquivo retorno, deixar zerada.
+        public decimal ValorPagoCredito { get; set; } // ValorPagoCredito deve ser preenchido com o valor que ser√° creditado na conta corrente. Se n√£o existir essa informa√ß√£o no arquivo retorno, deixar zerada.
         public decimal ValorJurosDia { get; set; }
         public decimal ValorMulta { get; set; }
         public decimal ValorDesconto { get; set; }
@@ -85,12 +85,12 @@ namespace Boleto2Net
         public DateTime DataDesconto { get; set; }
 
         /// <summary>
-        /// Banco no qual o boleto/tÌtulo foi quitado/recolhido
+        /// Banco no qual o boleto/t√≠tulo foi quitado/recolhido
         /// </summary>
         public string BancoCobradorRecebedor { get; set; }
         
         /// <summary>
-        /// AgÍncia na qual o boleto/tÌtulo foi quitado/recolhido
+        /// Ag√™ncia na qual o boleto/t√≠tulo foi quitado/recolhido
         /// </summary>
         public string AgenciaCobradoraRecebedora { get; set; }
 
@@ -122,27 +122,27 @@ namespace Boleto2Net
 
         public void ValidarDados()
         {
-            // Banco ObrigatÛrio
+            // Banco Obrigat√≥rio
             if (Banco == null)
-                throw new Exception("Boleto n„o possui Banco.");
+                throw new Exception("Boleto n√£o possui Banco.");
 
-            // Cedente ObrigatÛrio
+            // Cedente Obrigat√≥rio
             if (Banco.Cedente == null)
-                throw new Exception("Boleto n„o possui cedente.");
+                throw new Exception("Boleto n√£o possui cedente.");
 
-            // Conta Banc·ria ObrigatÛria
+            // Conta Banc√°ria Obrigat√≥ria
             if (Banco.Cedente.ContaBancaria == null)
-                throw new Exception("Boleto n„o possui conta banc·ria.");
+                throw new Exception("Boleto n√£o possui conta banc√°ria.");
 
-            // Sacado ObrigatÛrio
+            // Sacado Obrigat√≥rio
             if (Sacado == null)
-                throw new Exception("Boleto n„o possui sacado.");
+                throw new Exception("Boleto n√£o possui sacado.");
 
-            // Verifica se data do processamento È valida
+            // Verifica se data do processamento √© valida
             if (DataProcessamento == DateTime.MinValue)
                 DataProcessamento = DateTime.Now;
 
-            // Verifica se data de emiss„o È valida
+            // Verifica se data de emiss√£o √© valida
             if (DataEmissao == DateTime.MinValue)
                 DataEmissao = DateTime.Now;
 


### PR DESCRIPTION
A alteração para múltiplas carteiras (2018) ignora o recurso de leitura do arquivo de retorno sem especificar o cedente na conta bancária. Especificando um cedente "em branco" já evita o erro - ou seja, ele não é necessário...