### PR TITLE
Revert "Issue #292 - Implementei o código de cedente com 4 e 6 dígitos para o BB"

### DIFF
--- a/Boleto2.Net.Testes/BancoBrasilCarteira17_019Tests.cs
+++ b/Boleto2.Net.Testes/BancoBrasilCarteira17_019Tests.cs
@@ -10,8 +10,7 @@ namespace Boleto2Net.Testes
         readonly IBanco _banco;
         public BancoBrasilCarteira17019Tests()
         {
-            //Código de cedente com 4 dígitos
-            var contaBancariaCed4Digitos = new ContaBancaria
+            var contaBancaria = new ContaBancaria
             {
                 Agencia = "1234",
                 DigitoAgencia = "X",
@@ -24,41 +23,7 @@ namespace Boleto2Net.Testes
                 TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
             };
             _banco = Banco.Instancia(Bancos.BancoDoBrasil);
-            _banco.Cedente = Utils.GerarCedente("1234", "", "", contaBancariaCed4Digitos);
-            _banco.FormataCedente();
-
-            //Código de cedente com 6 dígitos
-            var contaBancariaCed6Digitos = new ContaBancaria
-            {
-                Agencia = "1234",
-                DigitoAgencia = "X",
-                Conta = "123456",
-                DigitoConta = "X",
-                CarteiraPadrao = "17",
-                VariacaoCarteiraPadrao = "019",
-                TipoCarteiraPadrao = TipoCarteira.CarteiraCobrancaSimples,
-                TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
-                TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
-            };
-            _banco = Banco.Instancia(Bancos.BancoDoBrasil);
-            _banco.Cedente = Utils.GerarCedente("123456", "", "", contaBancariaCed6Digitos);
-            _banco.FormataCedente();
-
-            //Código de cedente com 7 dígitos
-            var contaBancariaCed7Digitos = new ContaBancaria
-            {
-                Agencia = "1234",
-                DigitoAgencia = "X",
-                Conta = "123456",
-                DigitoConta = "X",
-                CarteiraPadrao = "17",
-                VariacaoCarteiraPadrao = "019",
-                TipoCarteiraPadrao = TipoCarteira.CarteiraCobrancaSimples,
-                TipoFormaCadastramento = TipoFormaCadastramento.ComRegistro,
-                TipoImpressaoBoleto = TipoImpressaoBoleto.Empresa
-            };
-            _banco = Banco.Instancia(Bancos.BancoDoBrasil);
-            _banco.Cedente = Utils.GerarCedente("1234567", "", "", contaBancariaCed7Digitos);
+            _banco.Cedente = Utils.GerarCedente("1234567", "", "", contaBancaria);
             _banco.FormataCedente();
         }
 

--- a/Boleto2.Net/Banco/Carteiras/BancoBrasil/BancoBrasilCarteira17.cs
+++ b/Boleto2.Net/Banco/Carteiras/BancoBrasil/BancoBrasilCarteira17.cs
@@ -20,65 +20,9 @@ namespace Boleto2Net
             if (IsNullOrWhiteSpace(boleto.NossoNumero))
                 throw new Exception("Nosso Número não informado.");
 
-            switch (boleto.Banco.Cedente.Codigo.Length)
-            {
-                case 4:
-                    FormataNossoNumero4dig(boleto);
-                    break;
-                case 6:
-                    FormataNossoNumero6dig(boleto);
-                    break;
-                case 7:
-                    FormataNossoNumero7dig(boleto);
-                    break;
-                default:
-                    throw new NotImplementedException("Não foi possível formatar o nosso número: Código do Cedente não tem 4, 6 ou 7 dígitos.");
-            }
-        }
-
-        private void FormataNossoNumero4dig(Boleto boleto)
-        {
-            boleto.NossoNumeroDV = Mod11(boleto.NossoNumero).ToString();
-            // Se o convênio for de 4 dígitos,
-            // o nosso número deve estar formatado corretamente (com 12 dígitos e iniciando com o código do convênio),
-            if (boleto.NossoNumero.Length == 12)
-            {
-                if (!boleto.NossoNumero.StartsWith(boleto.Banco.Cedente.Codigo))
-                    throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve iniciar com \"{boleto.Banco.Cedente.Codigo}\" e conter 12 dígitos.");
-            }
-            else
-            {
-                // ou deve ser informado com até 7 posições (será formatado para 12 dígitos pelo Boleto.Net).
-                if (boleto.NossoNumero.Length > 7)
-                    throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve iniciar com \"{boleto.Banco.Cedente.Codigo}\" e conter 7 dígitos.");
-                boleto.NossoNumero = $"{boleto.Banco.Cedente.Codigo}{boleto.NossoNumero.PadLeft(7, '0')}";
-            }
-
-            boleto.NossoNumeroFormatado = boleto.NossoNumero + boleto.NossoNumeroDV;
-        }
-
-        private void FormataNossoNumero6dig(Boleto boleto)
-        {
-            boleto.NossoNumeroDV = Mod11(boleto.NossoNumero).ToString();
-            // Se o convênio for de 6 dígitos,
-            // o nosso número deve estar formatado corretamente (com 12 dígitos e iniciando com o código do convênio),
-            if (boleto.NossoNumero.Length == 12)
-            {
-                if (!boleto.NossoNumero.StartsWith(boleto.Banco.Cedente.Codigo))
-                    throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve iniciar com \"{boleto.Banco.Cedente.Codigo}\" e conter 12 dígitos.");
-            }
-            else
-            {
-                // ou deve ser informado com até 5 posições (será formatado para 12 dígitos pelo Boleto.Net).
-                if (boleto.NossoNumero.Length > 5)
-                    throw new Exception($"Nosso Número ({boleto.NossoNumero}) deve iniciar com \"{boleto.Banco.Cedente.Codigo}\" e conter 5 dígitos.");
-                boleto.NossoNumero = $"{boleto.Banco.Cedente.Codigo}{boleto.NossoNumero.PadLeft(5, '0')}";
-            }
-            boleto.NossoNumeroFormatado = boleto.NossoNumero + boleto.NossoNumeroDV;
-        }
-
-        private void FormataNossoNumero7dig(Boleto boleto)
-        {
+            if (boleto.Banco.Cedente.Codigo.Length != 7)
+                throw new NotImplementedException("Não foi possível formatar o nosso número: Código do Cedente não tem 7 dígitos.");
+            
             // Se o convênio for de 7 dígitos,
             // o nosso número deve estar formatado corretamente (com 17 dígitos e iniciando com o código do convênio),
             if (boleto.NossoNumero.Length == 17)
@@ -98,47 +42,9 @@ namespace Boleto2Net
             boleto.NossoNumeroFormatado = boleto.NossoNumero;
         }
 
-        private int Mod11(string seq)
-        {
-            /* Variáveis
-             * -------------
-             * d - Dígito
-             * s - Soma
-             * p - Peso
-             * b - Base
-             * r - Resto
-             */
-
-            int d, s = 0, p = 2, b = 9;
-
-            for (int i = seq.Length - 1; i >= 0; i--)
-            {
-                s = s + (Convert.ToInt32(seq.Substring(i, 1)) * p);
-                if (p < b)
-                    p = p + 1;
-                else
-                    p = 2;
-            }
-
-            d = 11 - (s % 11);
-            if (d > 9)
-                d = 0;
-            return d;
-        }
-
         public string FormataCodigoBarraCampoLivre(Boleto boleto)
         {
-            switch (boleto.Banco.Cedente.Codigo.Length)
-            {
-                case 4:
-                    return $"{boleto.NossoNumero}{boleto.Banco.Cedente.ContaBancaria.Agencia.PadLeft(4, '0')}{boleto.Banco.Cedente.ContaBancaria.Conta.PadLeft(8, '0')}{boleto.Carteira}";
-                case 6:
-                    return $"{boleto.NossoNumero}{boleto.Banco.Cedente.ContaBancaria.Agencia.PadLeft(4, '0')}{boleto.Banco.Cedente.ContaBancaria.Conta.PadLeft(8, '0')}{boleto.Carteira}";
-                case 7:
-                    return $"000000{boleto.NossoNumeroFormatado}{boleto.Carteira}";
-                default:
-                    throw new NotImplementedException("Código do Cedente deve conter 4, 6 ou 7 dígitos.");
-            }
+            return $"000000{boleto.NossoNumero}{boleto.Carteira}";
         }
     }
 }


### PR DESCRIPTION
Reverts BoletoNet/boleto2net#301

Motivo:

No construtor, a variável _banco é instanciada com 4 dígitos, depois 6, depois 7... quando vai para os testes de geração de arquivos e geração dos boletos, ele continua testando apenas com cedente de 7 dígitos, que foi o último cedente atribuído na _banco.

É necessário criar 3 classes de testes diferentes... uma com 4 dígitos no cedente e gerar CNAB 240 , CNAB 400 e Boletos... outra com 6 dígitos e gerar cnab/boletos novamente, e por fim 7 dígitos que já estava validando antes dos ajustes.