### PR TITLE
Corrigindo extensão do arquivo de remessa - Sicredi

### DIFF
--- a/Boleto2.Net/Banco/BancoSicredi.cs
+++ b/Boleto2.Net/Banco/BancoSicredi.cs
@@ -52,7 +52,7 @@ namespace Boleto2Net
             var dia = agora.Day.ToString().PadLeft(2, '0');
 
             //Caso for gerado mais de um arquivo de remessa alterar a extensão do aquivo para "RM" + o contador do numero do arquivo de remessa gerado no dia
-            var nomeArquivoRemessa = string.Format("{0}{1}{2}.{3}", Cedente.Codigo, mes, dia, "CRM");
+            var nomeArquivoRemessa = string.Format("{0}{1}{2}.{3}", Cedente.Codigo, mes, dia, sequencial > 1 ? $"RM{sequencial}" : "REM");
 
             return nomeArquivoRemessa;
         }


### PR DESCRIPTION
Bom dia, corrigi a extensão do arquivo de remessa e comecei a usar o sequencial, caso tenha mais de uma remessa no dia o nome do arquivo não pode ser o mesmo, de acordo com este trecho da documentação.
![image](https://user-images.githubusercontent.com/54961255/128708729-1399e24a-54a0-4148-89a3-b6111ffd9681.png)
Caso esteja tudo certo, se possível, atualizar o nuget da biblioteca.
