### PR TITLE
Problema ao validar a remessa gerada

### DIFF
--- a/Boleto2.Net/Banco/BancoBrasil.cs
+++ b/Boleto2.Net/Banco/BancoBrasil.cs
@@ -664,7 +664,7 @@ namespace Boleto2Net
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0154, 001, 0, boleto.Avalista.TipoCPFCNPJ("0"), '0');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0155, 015, 0, boleto.Avalista.CPFCNPJ, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0170, 040, 0, boleto.Avalista.Nome, ' ');
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0210, 003, 0, string.Empty, ' ');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0210, 003, 0, string.Empty, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0213, 020, 0, string.Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0233, 008, 0, string.Empty, ' ');
                 reg.CodificarLinha();


### PR DESCRIPTION
Motivação: Realizei a alteração devido a um problema no segmento Q no leiaute CNAB240, pois ao validar o arquivo no validador de remessas estava retornando o seguinte problema

**POSIÇÃO:** 210 a 212
**NOME DO CAMPO:** 20.3Q - Cód. Bco. Corresp. na Compensação
**CONTEÚDO OBSERVADO:** [ ]
**ERRO/ALERTA:** Foi informado caractere não numérico ou brancos.
**SOLUÇÃO/RECOMENDAÇÃO:** Campo numérico: Verificar o preenchimento. / Preencher com zeros à esquerda.

Solução: tive que adicionar o zero onde estava puxando vazio

Link para o validador de leiautes: [https://gmtedi.bb.com.br/validaleiaute/#/](url)
 