### PR TITLE
Aplicação dos dias de protesto no arquivo de remessa do banco Itaú

### DIFF
--- a/Boleto2.Net/Banco/BancoItau.cs
+++ b/Boleto2.Net/Banco/BancoItau.cs
@@ -342,7 +342,7 @@ namespace Boleto2Net
                     reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0382, 004, 0, Empty, ' ');
                     reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0386, 006, 0, "0", '0');
                 }
-                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0392, 002, 0, "0", '0');
+                reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0392, 002, 0, boleto.DiasProtesto, '0');
                 reg.Adicionar(TTiposDadoEDI.ediAlphaAliEsquerda_____, 0394, 001, 0, Empty, ' ');
                 reg.Adicionar(TTiposDadoEDI.ediNumericoSemSeparador_, 0395, 006, 0, numeroRegistroGeral, '0');
                 reg.CodificarLinha();


### PR DESCRIPTION
Trecho do manual COBRANÇA BANCÁRIA - Intercâmbio Eletrônico de Arquivos - Layout de Arquivos – CNAB 400, página 19:

_Utilizada para agendar uma negativação ou protesto futuro sendo que o prazo de início de protesto
deverá ser indicado nas posições 392 à 393, a partir do vencimento. Caso seja informado '00' no
campo prazo, o processo de protesto será acionado 02 dias (corridos) após o vencimento. No caso da
ocorrência “11”, o beneficiário passa a ter prioridade no recebimento quando o pagador estiver com
falência decretada._