### PR TITLE
fix: evitar acúmulo de arquivos temporários na geração de PDF

### DIFF
--- a/Boleto2.Net/BoletoImpressao/BoletoBancario.cs
+++ b/Boleto2.Net/BoletoImpressao/BoletoBancario.cs
@@ -754,11 +754,18 @@ namespace Boleto2Net
             }
 
             var fnCodigoBarras = Path.GetTempFileName();
-            var cb = new BarCode2of5i(Boleto.CodigoBarra.CodigoDeBarras, _withBarras, _heightBarras, Boleto.CodigoBarra.CodigoDeBarras.Length);
-            cb.ToBitmap().Save(fnCodigoBarras);
+            try
+            {
+                var cb = new BarCode2of5i(Boleto.CodigoBarra.CodigoDeBarras, _withBarras, _heightBarras, Boleto.CodigoBarra.CodigoDeBarras.Length);
+                cb.ToBitmap().Save(fnCodigoBarras);
 
-            //return HtmlOffLine(fnCorte, fnLogo, fnBarra, fnPonto, fnBarraInterna, fnCodigoBarras).ToString();
-            return HtmlOffLine(null, fnLogo, fnBarra, fnCodigoBarras).ToString();
+                //return HtmlOffLine(fnCorte, fnLogo, fnBarra, fnPonto, fnBarraInterna, fnCodigoBarras).ToString();
+                return HtmlOffLine(null, fnLogo, fnBarra, fnCodigoBarras).ToString();
+            }
+            finally
+            {
+                File.Delete(fnCodigoBarras);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Contexto

Durante a geração de arquivos PDF (contendo o código de barras), também é criado um arquivo PNG temporário que é salvo na pasta do Windows Temp. No entanto, esse arquivo não estava sendo removido após o uso.

Com o tempo, a pasta Windows/Temp atingiu o limite de 65.535 arquivos temporários com o padrão tmpXXXX.tmp, imposto pelo Windows. Quando esse limite é alcançado, ocorre a exceção:

```
The file exists.\r\n
exceptionType: System.IO.IOException
stackTrace: 
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.Path.InternalGetTempFileName(Boolean checkHost)
   at Bo...
```

**Análise**

- A função MontaHtml gera sempre um PNG temporário.
- Esse arquivo não estava sendo descartado após o processamento.
- O acúmulo resultou no erro de produção e impactou outras aplicações no servidor que também dependiam da criação de arquivos temporários.

**Solução**

- Implementada a remoção do arquivo temporário após o uso.
- Dessa forma, evitamos o acúmulo desnecessário na pasta Temp e garantimos que novas operações possam continuar normalmente.